### PR TITLE
Store registry data in /data instead of /tmp.

### DIFF
--- a/deploy/kubernetes/local/registry-datastore.yml
+++ b/deploy/kubernetes/local/registry-datastore.yml
@@ -21,7 +21,7 @@ spec:
       volumes:
       - name: registrydata
         hostPath:
-          path: /tmp/registrydata
+          path: /data/registrydata
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
This should make it persistent, use less RAM, and avoid running out of
space in /tmp.