### PR TITLE
Add isAdmin flag to session DB and JWT, very simple authorization for registry API

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,6 +4,7 @@
     // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
+
         {
             "type": "node",
             "request": "launch",
@@ -44,6 +45,38 @@
             "args": [
                "${workspaceRoot}/magda-typescript-common/lib/test"
             ]
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "protocol": "inspector",
+            "name": "Launch Gateway",
+            "program": "${workspaceRoot}/magda-gateway/index.js",
+            "cwd": "${workspaceRoot}/magda-gateway",
+            "env": {
+                "JWT_SECRET": "squirrel",
+                "SESSION_SECRET": "keyboard cat",
+                "FACEBOOK_CLIENT_ID": "173073926555600",
+                "FACEBOOK_CLIENT_SECRET": "none",
+                "GOOGLE_CLIENT_ID": "275237095477-f7ej2gsvbl2alb8bcqcn7r5jk0ur719p.apps.googleusercontent.com",
+                "GOOGLE_CLIENT_SECRET": "none"
+            }
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "protocol": "inspector",
+            "name": "Launch Auth API",
+            "program": "${workspaceRoot}/magda-auth-api/lib/index.js",
+            "cwd": "${workspaceRoot}/magda-auth-api",
+            "env": {
+                "JWT_SECRET": "squirrel",
+                "SESSION_SECRET": "keyboard cat",
+                "FACEBOOK_CLIENT_ID": "173073926555600",
+                "FACEBOOK_CLIENT_SECRET": "none",
+                "GOOGLE_CLIENT_ID": "275237095477-f7ej2gsvbl2alb8bcqcn7r5jk0ur719p.apps.googleusercontent.com",
+                "GOOGLE_CLIENT_SECRET": "none"
+            }
         }
     ]
 }

--- a/magda-auth-api/package.json
+++ b/magda-auth-api/package.json
@@ -8,7 +8,8 @@
     "build:live": "nodemon --exec ./node_modules/.bin/ts-node -- ./index.ts",
     "docker-build-local": "create-docker-context-for-node-component --build --push --tag auto --local",
     "docker-build-prod": "create-docker-context-for-node-component --build --push --tag auto",
-    "postinstall": "tsc"
+    "postinstall": "npm run compile",
+    "compile": "tsc"
   },
   "dependencies": {
     "@magda/typescript-common": "0.0.26-SNAPSHOT",

--- a/magda-auth-api/src/db.ts
+++ b/magda-auth-api/src/db.ts
@@ -6,22 +6,22 @@ import arrayToMaybe from '@magda/typescript-common/lib/util/array-to-maybe';
 function getUser(id: string): Promise<Maybe<User>> {
   return pool
     .query(
-    'SELECT id, "displayName", email, "photoURL", source FROM users WHERE "id" = $1',
+    'SELECT id, "displayName", email, "photoURL", source, "isAdmin" FROM users WHERE "id" = $1',
     [id]
     ).then(res => arrayToMaybe(res.rows));
 }
 
 function getUserByExternalDetails(source: string, sourceId: string): Promise<Maybe<User>> {
   return pool
-    .query('SELECT id, "displayName", email, "photoURL", source, "sourceId" FROM users WHERE "sourceId" = $1 AND source = $2', [sourceId, source])
+    .query('SELECT id, "displayName", email, "photoURL", source, "sourceId", "isAdmin" FROM users WHERE "sourceId" = $1 AND source = $2', [sourceId, source])
     .then(res => arrayToMaybe(res.rows));
 }
 
 function createUser(user: User): Promise<User> {
   return pool
     .query(
-    'INSERT INTO users(id, "displayName", email, "photoURL", source, "sourceId") VALUES(uuid_generate_v4(), $1, $2, $3, $4, $5) RETURNING id',
-    [user.displayName, user.email, user.photoURL, user.source, user.sourceId]
+    'INSERT INTO users(id, "displayName", email, "photoURL", source, "sourceId", "isAdmin") VALUES(uuid_generate_v4(), $1, $2, $3, $4, $5, $6) RETURNING id',
+    [user.displayName, user.email, user.photoURL, user.source, user.sourceId, user.isAdmin]
     )
     .then(result => result.rows[0]);
 }

--- a/magda-auth-api/src/model.ts
+++ b/magda-auth-api/src/model.ts
@@ -7,5 +7,11 @@ export interface PublicUser {
 export interface User extends PublicUser {
   email: string,
   source: string,
-  sourceId: string
+  sourceId: string,
+  isAdmin: boolean
+}
+
+export interface UserToken {
+    id: string,
+    isAdmin: boolean
 }

--- a/magda-auth-db/scripts/init/init.sql
+++ b/magda-auth-db/scripts/init/init.sql
@@ -1,5 +1,5 @@
 CREATE DATABASE auth
-    WITH 
+    WITH
     OWNER = postgres
     ENCODING = 'UTF8'
     LC_COLLATE = 'en_US.utf8'
@@ -19,6 +19,7 @@ CREATE TABLE public.users
     "photoURL" character varying(200) COLLATE pg_catalog."default" NOT NULL,
     source character varying(20) COLLATE pg_catalog."default" NOT NULL,
     "sourceId" character varying(200) COLLATE pg_catalog."default" NOT NULL,
+    "isAdmin" boolean default false NOT NULL,
     CONSTRAINT users_pkey PRIMARY KEY (id),
     CONSTRAINT source_unique UNIQUE ("sourceId", source)
 )

--- a/magda-gateway/package.json
+++ b/magda-gateway/package.json
@@ -6,7 +6,8 @@
     "dev": "JWT_SECRET=squirrel SESSION_SECRET=squirrel FACEBOOK_CLIENT_ID=blah FACEBOOK_CLIENT_SECRET=blah GOOGLE_CLIENT_ID=blah GOOGLE_CLIENT_SECRET=blah npm run build:live",
     "build:live": "nodemon --exec ./node_modules/.bin/ts-node -- ./index.ts",
     "docker-build-local": "create-docker-context-for-node-component --build --push --tag auto --local",
-    "docker-build-prod": "create-docker-context-for-node-component --build --push --tag auto"
+    "docker-build-prod": "create-docker-context-for-node-component --build --push --tag auto",
+    "compile": "tsc"
   },
   "dependencies": {
     "@magda/auth-api": "^0.0.26-SNAPSHOT",

--- a/magda-gateway/src/api-proxy.ts
+++ b/magda-gateway/src/api-proxy.ts
@@ -17,7 +17,7 @@ proxy.on("proxyReq", function(
   options: any
 ) {
   if (req.user) {
-    const token = jwt.sign({ userId: req.user }, process.env.JWT_SECRET);
+    const token = jwt.sign({ userId: req.user.id, isAdmin: req.user.isAdmin }, process.env.JWT_SECRET);
     proxyReq.setHeader("X-Magda-Session", token);
   }
 });

--- a/magda-gateway/src/auth-router.ts
+++ b/magda-gateway/src/auth-router.ts
@@ -25,7 +25,7 @@ authRouter.use('/login/facebook', fbAuthRouter);
 authRouter.use('/login/ckan', ckanAuthRouter);
 
 authRouter.get("/profile", require("connect-ensure-login").ensureLoggedIn(), function (req, res) {
-    getUser(req.user).then(user =>
+    getUser(req.user.id).then(user =>
         res.render("profile", { user: user.valueOrThrow() })
     );
 });

--- a/magda-gateway/tsconfig.json
+++ b/magda-gateway/tsconfig.json
@@ -8,7 +8,7 @@
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
     // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
-    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    "sourceMap": true,                     /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
     // "outDir": "./",                        /* Redirect output structure to the directory. */
     // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */

--- a/magda-registry-api/build.sbt
+++ b/magda-registry-api/build.sbt
@@ -25,7 +25,8 @@ libraryDependencies ++= {
     "io.circe" %% "circe-generic" % "0.8.0",
     "io.circe" %% "circe-java8" % "0.8.0",
     "org.gnieh" %% "diffson-spray-json" % "2.1.2",
-    "net.virtual-void" %%  "json-lenses" % "0.6.2"
+    "net.virtual-void" %%  "json-lenses" % "0.6.2",
+    "com.auth0" % "java-jwt" % "3.2.0"
   )
 }
 

--- a/magda-registry-api/src/main/resources/application.conf
+++ b/magda-registry-api/src/main/resources/application.conf
@@ -14,3 +14,7 @@ db {
     user = "postgres"
   }
 }
+
+authorization {
+    skip = true
+}

--- a/magda-registry-api/src/main/resources/env-specific-config/host.conf
+++ b/magda-registry-api/src/main/resources/env-specific-config/host.conf
@@ -1,2 +1,2 @@
 http.port = 6100
-db.default.url = "jdbc:postgresql://localhost/postgres"
+db.default.url = "jdbc:postgresql://minikube.data.gov.au:30545/postgres"

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/Api.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/Api.scala
@@ -72,11 +72,28 @@ class Api(val webHookActor: ActorRef, implicit val config: Config, implicit val 
   def checkCredentials(allowAnonymous: Seq[HttpMethod], allowAuthenticated: Seq[HttpMethod]) = (request: RequestContext) => {
     if (allowAnonymous.contains(request.request.method)) {
       true
-    } else if (allowAuthenticated.contains(request.request.method)) {
-      true // TODO: check that this is an authenticated user
     } else {
-      false // TODO: check if we're admin
+      val user = getUserDetails(request)
+      if (allowAuthenticated.contains(request.request.method) && userIsAuthenticated(user)) {
+        true
+      } else if (userIsAdmin(user)) {
+        true
+      } else {
+        false
+      }
     }
+  }
+
+  def getUserDetails(request: RequestContext): String = {
+    ""
+  }
+
+  def userIsAuthenticated(user: String): Boolean = {
+    true
+  }
+
+  def userIsAdmin(user: String): Boolean = {
+    false
   }
 
   def checkAuthorization(allowAnonymous: Seq[HttpMethod], allowAuthenticated: Seq[HttpMethod]) = authorize(checkCredentials(allowAnonymous, allowAuthenticated))

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/Api.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/Api.scala
@@ -99,7 +99,6 @@ class Api(val webHookActor: ActorRef, implicit val config: Config, implicit val 
         case None => false
       }.map(_.get).headOption
 
-//        println(jwt.verify(request.request.header[headers.Authorization].map(_.credentials.token()).getOrElse("")))
       if (allowAuthenticated.contains(request.request.method) && userIsAuthenticated(sessionToken)) {
         true
       } else if (userIsAdmin(sessionToken)) {

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/Api.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/Api.scala
@@ -10,7 +10,7 @@ import akka.actor.ActorSystem
 import akka.event.Logging
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.model.StatusCodes._
-import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.{HttpMethod, HttpMethods, StatusCodes}
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server._
 import akka.stream.Materializer
@@ -69,18 +69,30 @@ class Api(val webHookActor: ActorRef, implicit val config: Config, implicit val 
 
   webHookActor ! WebHookActor.Process
 
+  def checkCredentials(allowAnonymous: Seq[HttpMethod], allowAuthenticated: Seq[HttpMethod]) = (request: RequestContext) => {
+    if (allowAnonymous.contains(request.request.method)) {
+      true
+    } else if (allowAuthenticated.contains(request.request.method)) {
+      true // TODO: check that this is an authenticated user
+    } else {
+      false // TODO: check if we're admin
+    }
+  }
+
+  def checkAuthorization(allowAnonymous: Seq[HttpMethod], allowAuthenticated: Seq[HttpMethod]) = authorize(checkCredentials(allowAnonymous, allowAuthenticated))
+
   implicit val timeout = Timeout(FiniteDuration(1, TimeUnit.SECONDS))
   val routes = cors() {
     handleExceptions(myExceptionHandler) {
       pathPrefix("v0") {
         path("ping") { complete("OK") } ~
-          pathPrefix("aspects") { new AspectsService(system, materializer).route } ~
-          pathPrefix("records") { new RecordsService(webHookActor, system, materializer).route } ~
-          pathPrefix("hooks") { new HooksService(system, materializer).route } ~
-          new SwaggerDocService("localhost", 9001, system).allRoutes ~
-          pathPrefix("swagger") {
-            getFromResourceDirectory("swagger") ~ pathSingleSlash(get(redirect("index.html", StatusCodes.PermanentRedirect)))
-          }
+        pathPrefix("aspects") { checkAuthorization(Seq(HttpMethods.GET), Seq()) { new AspectsService(system, materializer).route } } ~
+        pathPrefix("records") { checkAuthorization(Seq(HttpMethods.GET), Seq(HttpMethods.POST)) { new RecordsService(webHookActor, system, materializer).route } } ~
+        pathPrefix("hooks") { checkAuthorization(Seq(HttpMethods.GET), Seq()) { new HooksService(system, materializer).route } } ~
+        new SwaggerDocService("localhost", 9001, system).allRoutes ~
+        pathPrefix("swagger") {
+          getFromResourceDirectory("swagger") ~ pathSingleSlash(get(redirect("index.html", StatusCodes.PermanentRedirect)))
+        }
       }
     }
   }

--- a/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/ApiSpec.scala
+++ b/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/ApiSpec.scala
@@ -11,8 +11,11 @@ import scalikejdbc._
 abstract class ApiSpec extends FunSpec with ScalatestRouteTest with Matchers with Protocols with SprayJsonSupport {
   case class FixtureParam(api: Api, webHookActorProbe: TestProbe)
 
-  override def testConfigSource = "db.default.url = \"jdbc:postgresql://localhost/postgres?currentSchema=test\""
-//  override def testConfigSource = "db.default.url = \"jdbc:postgresql://192.168.99.100:30545/postgres?currentSchema=test\""
+  override def testConfigSource =
+    """
+      |db.default.url = "jdbc:postgresql://minikube.data.gov.au:30545/postgres?currentSchema=test"
+      |authorization.skip = true
+    """.stripMargin
 
   override def withFixture(test: OneArgTest) = {
     val webHookActorProbe = TestProbe()


### PR DESCRIPTION
Currently the registry authorization is disabled as a result of `authorization.skip=true` in registry's application.conf.