### PR TITLE
fix dataset source on homepage

### DIFF
--- a/magda-web-client/src/actions/featuredDatasetsActions.js
+++ b/magda-web-client/src/actions/featuredDatasetsActions.js
@@ -30,7 +30,7 @@ export function fetchFeaturedDatasetsFromRegistry(ids: Array<string>):Object{
       return false
     }
     dispatch(requestDatasets(ids))
-    const fetches = ids.map(id=>fetch(config.registryUrl + `/records/${encodeURIComponent(id)}?aspect=dcat-dataset-strings&optionalAspect=dataset-publisher`).then(response=>response.json()));
+    const fetches = ids.map(id=>fetch(config.registryUrl + `/records/${encodeURIComponent(id)}?aspect=dcat-dataset-strings&optionalAspect=dataset-publisher&optionalAspect=source`).then(response=>response.json()));
     Promise.all(fetches).then(jsons=>dispatch(receiveDatasets(jsons)))
   }
 }

--- a/magda-web-client/src/helpers/record.js
+++ b/magda-web-client/src/helpers/record.js
@@ -95,6 +95,8 @@ export function parseDataset(dataset: Record) {
 
   const publisherDetails=aspects['dataset-publisher'] && aspects['dataset-publisher']['publisher']['aspects'] ? aspects['dataset-publisher']['publisher']['aspects']['organization-details'] : {}
 
+  const catalog = aspects['source'] ? aspects['source']['name'] : '';
+
   const source = distributions.map(d=> {
       const distributionAspects = d['aspects'] || {};
       const info = distributionAspects['dcat-distribution-strings'] || {};
@@ -109,6 +111,6 @@ export function parseDataset(dataset: Record) {
       }
   });
   return {
-      identifier, title, issuedDate, updatedDate, landingPage, tags, publisher, description, distribution, source, temporalCoverage, spatialCoverage, publisherDetails
+      identifier, title, issuedDate, updatedDate, landingPage, tags, publisher, description, distribution, source, temporalCoverage, spatialCoverage, publisherDetails, catalog
   }
 };


### PR DESCRIPTION
query "source" in featured dataset
I'm calling it `catalog` for now to be consistent with search, also the source field is already taken in the UI. We can refactor this later