### PR TITLE
Add link status icon to distributions on dataset page

### DIFF
--- a/magda-web-client/src/Dataset/DatasetDetails.js
+++ b/magda-web-client/src/Dataset/DatasetDetails.js
@@ -30,7 +30,7 @@ class DatasetDetails extends Component {
                   </div>
                   <div className='dataset-details-source'>
                       <h3 className='section-heading'>Data and APIs</h3>
-                      <div className='white-box'>{dataset.distributions.map(s=> renderDistribution(s.format, s.id, s.title, s.license, datasetId))}</div>
+                      <div className='white-box'>{dataset.distributions.map(s=> renderDistribution(s.format, s.id, s.title, s.license, datasetId, s.linkStatusAvailable, s.linkActive))}</div>
                   </div>
                   <div className='dataset-details-temporal-coverage'>
                       <h3 className='section-heading'>Temporal coverage</h3>

--- a/magda-web-client/src/UI/Distribution.js
+++ b/magda-web-client/src/UI/Distribution.js
@@ -4,7 +4,9 @@ import React from 'react';
 import { Link } from 'react-router';
 import './Distribution.css';
 
-export default function renderDistribution(distributionFormat: string, distributionId: string, distributionTitle: string, distributionLicense: string, datasetId: string){
+export default function renderDistribution(distributionFormat: string, distributionId: string, distributionTitle: string, distributionLicense: string, datasetId: string, linkStatusAvailable: boolean, linkActive: boolean){
+  const linkIconClassName = linkActive ? '' : 'text-danger'; // Colour link icon red if link is broken
+  const linkIconTitle = linkActive ? 'Download link working' : 'Download link may be broken';
   return <div className={`distribution media clearfix ${distributionFormat} distribution__media-object`} key={distributionId}>
           <div className='media-left'>
           <CustomIcons name={distributionFormat}/>
@@ -13,5 +15,11 @@ export default function renderDistribution(distributionFormat: string, distribut
            <h3><Link to={`/dataset/${encodeURIComponent(datasetId)}/distribution/${encodeURIComponent(distributionId)}`}>{distributionTitle}({distributionFormat})</Link></h3>
            <div className='distribution__license'>{distributionLicense}</div>
           </div>
+          {
+            linkStatusAvailable && <div className='media-right'>
+              <i className={`fa fa-link fa-2 fa-rotate-90 ${linkIconClassName}`} title={linkIconTitle} aria-hidden="true"></i>
+            </div>
+          }
+
         </div>
 }

--- a/magda-web-client/src/actions/recordActions.js
+++ b/magda-web-client/src/actions/recordActions.js
@@ -52,7 +52,7 @@ export function requestDistributionError(error: number): RecordAction {
 export function fetchDatasetFromRegistry(id: string):Function{
   return (dispatch: Function)=>{
     dispatch(requestDataset(id))
-    let url : string = config.registryUrl + `/records/${encodeURIComponent(id)}?aspect=dcat-dataset-strings&optionalAspect=dcat-distribution-strings&optionalAspect=dataset-distributions&optionalAspect=temporal-coverage&dereference=true&optionalAspect=dataset-publisher&optionalAspect=source`;
+    let url : string = config.registryUrl + `/records/${encodeURIComponent(id)}?aspect=dcat-dataset-strings&optionalAspect=dcat-distribution-strings&optionalAspect=dataset-distributions&optionalAspect=temporal-coverage&dereference=true&optionalAspect=dataset-publisher&optionalAspect=source&optionalAspect=link-status`;
     console.log(url);
     return fetch(url)
     .then(response => {

--- a/magda-web-client/src/helpers/record.js
+++ b/magda-web-client/src/helpers/record.js
@@ -169,6 +169,9 @@ const defaultDistributionAspect = {
     updatedDate: null,
     license: null,
     description: null,
+  },
+  'source-link-status': {
+    status: null
   }
 }
 
@@ -211,6 +214,7 @@ export function parseDataset(dataset?: RawDataset): ParsedDataset {
   const distributions = distribution['distributions'].map(d=> {
       const distributionAspects = d['aspects'];
       const info = distributionAspects['dcat-distribution-strings'] || defaultDistributionAspect['dcat-distribution-strings'];
+      const linkStatus = distributionAspects['source-link-status'] || {};
       return {
           id: d['id'],
           title: d['name'],
@@ -219,6 +223,8 @@ export function parseDataset(dataset?: RawDataset): ParsedDataset {
           format: info.format || 'Unknown format',
           license: (!info.license || info.license === 'notspecified') ? 'License restrictions unknown' : info.license,
           description: info.description || 'No description provided',
+          linkStatusAvailable: Boolean(linkStatus.status), // Link status is available if status is non-empty string
+          linkActive: linkStatus.status === 'active',
           updatedDate: info.modified ? getDateString(info.modified) : 'unknown date'
       }
   });


### PR DESCRIPTION
The icon is:
- Black when link is marked "active"
- Red when a link is marked "broken"
- Not displayed when a distribution is not marked (the sleuther hasn't looked at the distribution yet or the distribution didn't have a downloadURL)