### PR TITLE
Stop generator generating " " format names.

### DIFF
--- a/magda-int-test/src/test/scala/au/csiro/data61/magda/test/util/Generators.scala
+++ b/magda-int-test/src/test/scala/au/csiro/data61/magda/test/util/Generators.scala
@@ -283,7 +283,7 @@ object Generators {
     MediaTypes.`text/csv`,
     MediaTypes.`application/json`,
     MediaTypes.`application/octet-stream`))
-  val formatNameGen = listSizeBetween(1, 3, nonEmptyTextWithStopWordsGen.map(removeFilterWords).map(_.take(50).trim)).map(_.mkString(" "))
+  val formatNameGen = listSizeBetween(1, 3, nonEmptyTextWithStopWordsGen.map(removeFilterWords).map(_.take(50).trim)).map(_.mkString(" ")).suchThat(!_.trim.isEmpty())
   def randomFormatGen(inputCache: mutable.Map[String, List[_]]) = cachedListGen("randomFormat", formatNameGen, 5)(inputCache)
 
   def textGen(inner: Gen[List[String]]) = inner


### PR DESCRIPTION
This killed this test:
https://travis-ci.org/TerriaJS/magda/builds/252232905?utm_source=github_status&utm_medium=notification