### PR TITLE
Add PUT service for webhooks

### DIFF
--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/HooksService.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/HooksService.scala
@@ -47,31 +47,31 @@ class HooksService(system: ActorSystem, materializer: Materializer) extends Prot
   ))
   def getById = get { path(Segment) { (id: String) => {
     DB readOnly { session =>
-      HookPersistence.getById(session, id.toInt) match {
+      HookPersistence.getById(session, id) match {
         case Some(hook) => complete(hook)
         case None => complete(StatusCodes.NotFound, BadRequest("No web hook exists with that ID."))
       }
     }
   } } }
 
-//  @Path("/{id}")
-//  @ApiOperation(value = "Modify an aspect by ID", nickname = "putById", httpMethod = "PUT", response = classOf[AspectDefinition],
-//    notes = "Modifies the aspect with a given ID.  If an aspect with the ID does not yet exist, it is created.")
-//  @ApiImplicitParams(Array(
-//    new ApiImplicitParam(name = "id", required = true, dataType = "string", paramType = "path", value = "ID of the aspect to be saved."),
-//    new ApiImplicitParam(name = "aspect", required = true, dataType = "au.csiro.data61.magda.model.Registry$AspectDefinition", paramType = "body", value = "The aspect to save.")
-//  ))
-//  def putById = put { path(Segment) { (id: String) => {
-//    entity(as[AspectDefinition]) { aspect =>
-//      DB localTx { session =>
-//        AspectPersistence.putById(session, id, aspect) match {
-//          case Success(result) => complete(result)
-//          case Failure(exception) => complete(StatusCodes.BadRequest, BadRequest(exception.getMessage))
-//        }
-//      }
-//    }
-//  } } }
-//
+  @Path("/{id}")
+  @ApiOperation(value = "Modify a web hook by ID", nickname = "putById", httpMethod = "PUT", response = classOf[WebHook],
+    notes = "Modifies the web hook with a given ID.  If a web hook with the ID does not yet exist, it is created.")
+  @ApiImplicitParams(Array(
+    new ApiImplicitParam(name = "id", required = true, dataType = "string", paramType = "path", value = "ID of the aspect to be saved."),
+    new ApiImplicitParam(name = "hook", required = true, dataType = "au.csiro.data61.magda.model.Registry$WebHook", paramType = "body", value = "The web hook to save.")
+  ))
+  def putById = put { path(Segment) { (id: String) => {
+    entity(as[WebHook]) { hook =>
+      DB localTx { session =>
+        HookPersistence.putById(session, id, hook) match {
+          case Success(result) => complete(result)
+          case Failure(exception) => complete(StatusCodes.BadRequest, BadRequest(exception.getMessage))
+        }
+      }
+    }
+  } } }
+
 //  @Path("/{id}")
 //  @ApiOperation(value = "Modify an aspect by applying a JSON Patch", nickname = "patchById", httpMethod = "PATCH", response = classOf[AspectDefinition],
 //    notes = "The patch should follow IETF RFC 6902 (https://tools.ietf.org/html/rfc6902).")
@@ -93,7 +93,7 @@ class HooksService(system: ActorSystem, materializer: Materializer) extends Prot
   def route =
     getAll ~
     create ~
-    getById
-//      putById ~
+    getById ~
+    putById
 //      patchById
 }

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/SwaggerDocService.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/SwaggerDocService.scala
@@ -29,7 +29,7 @@ class SwaggerDocService(address: String, port: Int, system: ActorSystem) extends
     ru.typeOf[HooksService])
   override val host = ""
   override val info = Info(version = "0.1")
-  override val basePath = "/v0"
+  override val basePath = "/api/v0/registry"
   lazy val allRoutes =
     routes ~
       path(apiDocsBase / "json-patch.json") {

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/SwaggerDocService.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/SwaggerDocService.scala
@@ -29,7 +29,7 @@ class SwaggerDocService(address: String, port: Int, system: ActorSystem) extends
     ru.typeOf[HooksService])
   override val host = ""
   override val info = Info(version = "0.1")
-  override val basePath = "/api/v0/registry"
+  override val basePath = "/v0"
   lazy val allRoutes =
     routes ~
       path(apiDocsBase / "json-patch.json") {

--- a/magda-registry-datastore/sql/V1_2__WebHooks_String_Id.sql
+++ b/magda-registry-datastore/sql/V1_2__WebHooks_String_Id.sql
@@ -1,0 +1,16 @@
+ALTER TABLE WebHookEvents ADD COLUMN newWebHookId VARCHAR(100);
+UPDATE WebHookEvents SET newWebHookId = webHookId;
+ALTER TABLE WebHooks ADD COLUMN newWebHookId VARCHAR(100);
+UPDATE WebHooks SET newWebHookId = webHookId;
+
+ALTER TABLE WebHookEvents ALTER COLUMN newWebHookId SET NOT NULL;
+ALTER TABLE WebHooks ALTER COLUMN newWebHookId SET NOT NULL;
+
+ALTER TABLE WebHookEvents DROP COLUMN webHookId;
+ALTER TABLE WebHooks DROP COLUMN webHookId;
+
+ALTER TABLE WebHookEvents RENAME COLUMN newWebHookId TO webHookId;
+ALTER TABLE WebHooks RENAME COLUMN newWebHookId TO webHookId;
+
+ALTER TABLE WebHooks ADD PRIMARY KEY (webHookId);
+ALTER TABLE WebHookEvents ADD FOREIGN KEY (webHookId) REFERENCES WebHooks;

--- a/magda-scala-common/src/main/scala/au/csiro/data61/magda/model/Registry.scala
+++ b/magda-scala-common/src/main/scala/au/csiro/data61/magda/model/Registry.scala
@@ -53,7 +53,7 @@ object Registry {
   }
 
   case class WebHook(
-    id: Option[Int] = None,
+    id: Option[String] = None,
     userId: Option[Int],
     name: String,
     active: Boolean,

--- a/magda-typescript-common/src/generated/registry/api.ts
+++ b/magda-typescript-common/src/generated/registry/api.ts
@@ -135,7 +135,7 @@ export class RegistryEvent {
 }
 
 export class WebHook {
-    'id': any;
+    'id': string;
     'userId': any;
     'name': string;
     'active': boolean;
@@ -1537,6 +1537,65 @@ export class WebHooksApi {
             uri: localVarPath,
             useQuerystring: this._useQuerystring,
             json: true,
+        };
+
+        this.authentications.default.applyToRequest(requestOptions);
+
+        if (Object.keys(formParams).length) {
+            if (useFormData) {
+                (<any>requestOptions).formData = formParams;
+            } else {
+                requestOptions.form = formParams;
+            }
+        }
+        return new Promise<{ response: http.IncomingMessage; body: WebHook;  }>((resolve, reject) => {
+            request(requestOptions, (error, response, body) => {
+                if (error) {
+                    reject(error);
+                } else {
+                    if (response.statusCode >= 200 && response.statusCode <= 299) {
+                        resolve({ response: response, body: body });
+                    } else {
+                        reject({ response: response, body: body });
+                    }
+                }
+            });
+        });
+    }
+    /**
+     * Modify a web hook by ID
+     * Modifies the web hook with a given ID.  If a web hook with the ID does not yet exist, it is created.
+     * @param id ID of the aspect to be saved.
+     * @param hook The web hook to save.
+     */
+    public putById (id: string, hook: WebHook) : Promise<{ response: http.IncomingMessage; body: WebHook;  }> {
+        const localVarPath = this.basePath + '/hooks/{id}'
+            .replace('{' + 'id' + '}', String(id));
+        let queryParameters: any = {};
+        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
+        let formParams: any = {};
+
+
+        // verify required parameter 'id' is not null or undefined
+        if (id === null || id === undefined) {
+            throw new Error('Required parameter id was null or undefined when calling putById.');
+        }
+
+        // verify required parameter 'hook' is not null or undefined
+        if (hook === null || hook === undefined) {
+            throw new Error('Required parameter hook was null or undefined when calling putById.');
+        }
+
+        let useFormData = false;
+
+        let requestOptions: request.Options = {
+            method: 'PUT',
+            qs: queryParameters,
+            headers: headerParams,
+            uri: localVarPath,
+            useQuerystring: this._useQuerystring,
+            json: true,
+            body: hook,
         };
 
         this.authentications.default.applyToRequest(requestOptions);


### PR DESCRIPTION
It can be used to both create and update web hooks.

Also changed the `webHookId` to be a user-specified string instead of an ID.  If an ID is not given to the POST service, a UUID is used.