### PR TITLE
Don't expode if webhooks experience an error.

### DIFF
--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/WebHookProcessor.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/WebHookProcessor.scala
@@ -103,7 +103,9 @@ class WebHookProcessor(actorSystem: ActorSystem, implicit val executionContext: 
 
               response.status.isSuccess()
             })
-          })
+          }).recover {
+            case _ => false
+          }
         }).runFold(WebHookProcessingResult(0, 0))((results, postResult) => results match {
           // Count successful and failed payload deliveries
           case WebHookProcessingResult(successfulPosts, failedPosts) => if (postResult) WebHookProcessingResult(successfulPosts + 1, failedPosts) else WebHookProcessingResult(successfulPosts, failedPosts + 1)

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/WebHookProcessor.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/WebHookProcessor.scala
@@ -28,7 +28,7 @@ class WebHookProcessor(actorSystem: ActorSystem, implicit val executionContext: 
         HookPersistence.getAll(session).filter(hook => hook.lastEvent.getOrElse(0l) < latestEventId)
       }
     }.flatMap(webHooksToProcess => {
-      // Process up to 'webHooksToProcess' in parallel
+      // Process up to 'simultaneousInvocations' in parallel
       Source(webHooksToProcess).mapAsync(simultaneousInvocations)(webHook => {
         // Create a stream of all events this WebHook hasn't seen yet
         val events = EventPersistence.streamEventsSince(webHook.lastEvent.get)
@@ -37,7 +37,7 @@ class WebHookProcessor(actorSystem: ActorSystem, implicit val executionContext: 
         events.grouped(maxEvents).map(events => {
           val relevantEventTypes = webHook.eventTypes
 
-          var changeEvents = events.filter(event => relevantEventTypes.contains(event.eventType))
+          val changeEvents = events.filter(event => relevantEventTypes.contains(event.eventType))
           val recordChangeEvents = events.filter(event => event.eventType.isRecordEvent || event.eventType.isRecordAspectEvent)
           val aspectDefinitionChangeEvents = events.filter(event => event.eventType.isAspectDefinitionEvent)
 


### PR DESCRIPTION
This doesn't actually fix anything, but at least will give us a stack trace when webhook processing fails, rather than silently breaking all webhook processing from then on.