### PR TITLE
Make the docker images smaller

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -111,7 +111,7 @@
             "protocol": "inspector",
             "name": "create-docker-context-for-node-component",
             "program": "${workspaceRoot}/scripts/create-docker-context-for-node-component.js",
-            "cwd": "${workspaceRoot}/magda-auth-api",
+            "cwd": "${workspaceRoot}/magda-gateway",
             "args": [
                "--output", "foo.tar.gz"
             ]

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -104,6 +104,17 @@
                "--selector", "service=combined-db",
                "--port", "5432"
             ]
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "protocol": "inspector",
+            "name": "create-docker-context-for-node-component",
+            "program": "${workspaceRoot}/scripts/create-docker-context-for-node-component.js",
+            "cwd": "${workspaceRoot}/magda-auth-api",
+            "args": [
+               "--output", "foo.tar.gz"
+            ]
         }
     ]
 }

--- a/deploy/helm/create-auth-secrets.sh
+++ b/deploy/helm/create-auth-secrets.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-echo {\"apiVersion\": \"v1\", \"kind\": \"Secret\", \"metadata\": {\"name\": \"auth-secrets\"}, \"type\": \"Opaque\", \"data\": {\"jwt-secret\": \"$(openssl rand -base64 128 | tr -d '\r\n' | base64 -w 0)\", \"session-secret\":\"$(openssl rand -base64 128 | tr -d '\r\n' | base64 -w 0)\"}} | kubectl create -f -
+echo {\"apiVersion\": \"v1\", \"kind\": \"Secret\", \"metadata\": {\"name\": \"auth-secrets\"}, \"type\": \"Opaque\", \"data\": {\"jwt-secret\": \"$(openssl rand -base64 128 | tr -d '\r\n' | base64 -w 0)\", \"session-secret\":\"$(openssl rand -base64 128 | tr -d '\r\n' | base64 | tr -d '\r\n')\"}} | kubectl create -f -

--- a/deploy/package.json
+++ b/deploy/package.json
@@ -11,7 +11,7 @@
   },
   "author": "",
   "license": "Apache-2.0",
-  "dependencies": {
+  "devDependencies": {
     "@magda/scripts": "^0.0.29-SNAPSHOT",
     "fs-extra": "^2.1.2",
     "klaw-sync": "^2.1.0",

--- a/magda-ckan-connector/package.json
+++ b/magda-ckan-connector/package.json
@@ -17,7 +17,7 @@
     "@magda/scripts": "^0.0.29-SNAPSHOT",
     "@types/node": "^8.0.14",
     "@types/request": "^2.0.0",
-    "@types/urijs": "^1.15.31",
+    "@types/urijs": "^1.15.34",
     "@types/yargs": "^6.6.0",
     "typescript": "~2.4.0"
   },
@@ -26,7 +26,7 @@
     "@magda/typescript-common": "^0.0.29-SNAPSHOT",
     "moment": "^2.17.1",
     "request": "^2.79.0",
-    "urijs": "^1.18.7",
+    "urijs": "^1.18.12",
     "yargs": "^8.0.1"
   },
   "config": {

--- a/magda-csw-connector/package.json
+++ b/magda-csw-connector/package.json
@@ -18,7 +18,7 @@
     "@types/lodash": "^4.14.66",
     "@types/node": "^8.0.14",
     "@types/request": "^2.0.0",
-    "@types/urijs": "^1.15.31",
+    "@types/urijs": "^1.15.34",
     "@types/xml2js": "0.0.33",
     "@types/xmldom": "^0.1.29",
     "@types/yargs": "^6.6.0",
@@ -31,7 +31,7 @@
     "lodash": "^4.17.4",
     "moment": "^2.17.1",
     "request": "^2.79.0",
-    "urijs": "^1.18.7",
+    "urijs": "^1.18.12",
     "xml2js": "^0.4.17",
     "xmldom": "^0.1.27",
     "yargs": "^8.0.1"

--- a/magda-gateway/package.json
+++ b/magda-gateway/package.json
@@ -14,7 +14,6 @@
   },
   "dependencies": {
     "@magda/auth-api": "^0.0.29-SNAPSHOT",
-    "@types/urijs": "^1.15.33",
     "body-parser": "^1.13.2",
     "cheerio": "^0.22.0",
     "connect-ensure-login": "^0.1.1",
@@ -37,7 +36,7 @@
     "passport-local": "^1.0.0",
     "pg": "^6.4.0",
     "tsmonad": "^0.7.2",
-    "urijs": "^1.18.10",
+    "urijs": "^1.18.12",
     "yargs": "^8.0.2"
   },
   "devDependencies": {
@@ -49,6 +48,7 @@
     "@types/passport-facebook": "^2.1.4",
     "@types/passport-local": "^1.0.30",
     "@types/pg": "^6.1.41",
+    "@types/urijs": "^1.15.34",
     "@types/yargs": "^8.0.2",
     "typescript": "~2.4.0"
   },

--- a/magda-preview-map/package.json
+++ b/magda-preview-map/package.json
@@ -66,7 +66,7 @@
     "terriajs-catalog-editor": "^0.2.0",
     "terriajs-cesium": "1.33.0",
     "terriajs-schema": "latest",
-    "urijs": "^1.17.1",
+    "urijs": "^1.18.12",
     "url-loader": "^0.5.7",
     "webpack": "^2.2.1",
     "webpack-dev-server": "^2.4.1",

--- a/magda-project-open-data-connector/package.json
+++ b/magda-project-open-data-connector/package.json
@@ -16,7 +16,7 @@
     "@magda/scripts": "^0.0.29-SNAPSHOT",
     "@types/node": "^8.0.14",
     "@types/request": "^2.0.0",
-    "@types/urijs": "^1.15.31",
+    "@types/urijs": "^1.15.34",
     "@types/yargs": "^6.6.0",
     "typescript": "~2.4.0"
   },
@@ -25,7 +25,7 @@
     "@magda/typescript-common": "^0.0.29-SNAPSHOT",
     "moment": "^2.17.1",
     "request": "^2.79.0",
-    "urijs": "^1.18.7",
+    "urijs": "^1.18.12",
     "yargs": "^8.0.1"
   },
   "config": {

--- a/magda-registry-aspects/package.json
+++ b/magda-registry-aspects/package.json
@@ -4,5 +4,10 @@
   "description": "Common aspects for use with the registry.",
   "scripts": {},
   "author": "",
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "config": {
+      "docker": {
+          "include": "*"
+      }
+  }
 }

--- a/magda-sleuther-broken-link/package.json
+++ b/magda-sleuther-broken-link/package.json
@@ -25,7 +25,7 @@
     "@types/node": "^8.0.14",
     "@types/request": "^2.0.0",
     "@types/sinon": "^2.3.3",
-    "@types/urijs": "^1.15.31",
+    "@types/urijs": "^1.15.34",
     "chai": "^4.1.0",
     "dns-proxy": "^0.5.0",
     "jsverify": "^0.8.2",
@@ -42,7 +42,7 @@
     "lodash": "^4.17.4",
     "lru-cache": "4.0.2",
     "request": "^2.79.0",
-    "urijs": "^1.18.7"
+    "urijs": "^1.18.12"
   },
   "config": {
     "registryUrl": "http://localhost:6101/v0",

--- a/magda-sleuther-framework/package.json
+++ b/magda-sleuther-framework/package.json
@@ -38,5 +38,10 @@
     "express": "^4.15.3",
     "isomorphic-fetch": "^2.2.1",
     "lodash": "^4.17.4"
+  },
+  "config": {
+      "docker": {
+          "include": "node_modules dist"
+      }
   }
 }

--- a/magda-sleuther-framework/package.json
+++ b/magda-sleuther-framework/package.json
@@ -15,12 +15,15 @@
     "@magda/scripts": "^0.0.29-SNAPSHOT",
     "@types/chai": "^4.0.1",
     "@types/express": "^4.0.36",
+    "@types/isomorphic-fetch": "0.0.34",
     "@types/lodash": "^4.14.68",
     "@types/mocha": "^2.2.41",
     "@types/nock": "^8.2.1",
     "@types/sinon": "^2.3.3",
     "@types/supertest": "^2.0.2",
+    "chai": "^4.1.0",
     "jsverify": "^0.8.2",
+    "mocha": "^3.4.2",
     "mocha-testcheck": "^1.0.0-rc.0",
     "nock": "^9.0.14",
     "sinon": "^2.4.1",
@@ -31,12 +34,9 @@
   "dependencies": {
     "@magda/registry-aspects": "^0.0.29-SNAPSHOT",
     "@magda/typescript-common": "^0.0.29-SNAPSHOT",
-    "@types/isomorphic-fetch": "0.0.34",
     "body-parser": "^1.17.2",
-    "chai": "^4.1.0",
     "express": "^4.15.3",
     "isomorphic-fetch": "^2.2.1",
-    "lodash": "^4.17.4",
-    "mocha": "^3.4.2"
+    "lodash": "^4.17.4"
   }
 }

--- a/magda-typescript-common/package.json
+++ b/magda-typescript-common/package.json
@@ -38,10 +38,8 @@
     "urijs": "^1.18.7"
   },
   "config": {
-    "registryUrl": "http://localhost:6101/v0",
     "docker": {
-      "name": "data61/magda-ckan-connector",
-      "include": "aspect-templates dist Dockerfile node_modules"
+      "include": "dist node_modules"
     }
   }
 }

--- a/magda-typescript-common/package.json
+++ b/magda-typescript-common/package.json
@@ -39,7 +39,7 @@
   },
   "config": {
     "docker": {
-      "include": "dist node_modules"
+      "include": "node_modules dist"
     }
   }
 }

--- a/magda-typescript-common/package.json
+++ b/magda-typescript-common/package.json
@@ -19,7 +19,7 @@
     "@types/mocha": "^2.2.41",
     "@types/node": "^8.0.14",
     "@types/request": "^2.0.0",
-    "@types/urijs": "^1.15.31",
+    "@types/urijs": "^1.15.34",
     "@types/uuid": "^3.4.0",
     "chai": "^4.0.1",
     "jsverify": "^0.8.2",
@@ -35,7 +35,7 @@
     "moment": "^2.17.1",
     "request": "^2.79.0",
     "tsmonad": "^0.7.2",
-    "urijs": "^1.18.7"
+    "urijs": "^1.18.12"
   },
   "config": {
     "docker": {

--- a/magda-web-client/package.json
+++ b/magda-web-client/package.json
@@ -17,31 +17,27 @@
     "eject": "react-scripts eject",
     "watch": "react-scripts build --watch"
   },
+  "dependencies": {
+  },
   "devDependencies": {
     "@magda/scripts": "^0.0.29-SNAPSHOT",
+    "d3-drag": "^1.0.1",
+    "d3-selection": "^1.0.2",
     "deep-freeze": "0.0.1",
+    "draft-js-mention-plugin": "TerriaJS/draft-js-mention-plugin#v2.1.0",
+    "draft-js-plugins-editor": "2.0.0-rc2",
+    "draft-js": "^0.10.1",
+    "es6-promise": "^4.1.0",
     "es6-shim": "^0.35.3",
     "es6-symbol": "^3.1.1",
     "expect": "^1.20.2",
-    "flow-bin": "^0.39.0",
-    "npm-run-all": "^4.0.1",
-    "react-scripts": "^1.0.10",
-    "redux-mock-store": "^1.2.1",
-    "typescript": "~2.4.0"
-  },
-  "dependencies": {
-    "d3-drag": "^1.0.1",
-    "d3-selection": "^1.0.2",
-    "draft-js": "^0.10.1",
-    "draft-js-mention-plugin": "TerriaJS/draft-js-mention-plugin#v2.1.0",
-    "draft-js-plugins-editor": "2.0.0-rc2",
-    "es6-promise": "^4.1.0",
     "fast-xml-parser": "^2.6.0",
     "fetch-mock": "^5.8.1",
+    "flow-bin": "^0.39.0",
     "immutable": "^3.8.1",
     "isomorphic-fetch": "^2.2.1",
-    "leaflet": "^0.7.7",
     "leaflet-mapbox-vector-tile": "TerriaJS/Leaflet.MapboxVectorTile",
+    "leaflet": "^0.7.7",
     "lodash.debounce": "^4.0.8",
     "lodash.find": "^4.6.0",
     "lodash.findindex": "^4.6.0",
@@ -53,35 +49,44 @@
     "markdown-with-front-matter-loader": "^0.1.0",
     "marked": "^0.3.6",
     "node-sass": "^4.5.0",
+    "npm-run-all": "^4.0.1",
     "openlayers": "^4.1.1",
     "papaparse": "^4.3.3",
     "pretty-date": "^0.2.0",
     "prop-types": "^15.5.10",
     "query-string": "^4.3.4",
     "re-base": "^2.7.0",
-    "react": "^15.6.1",
     "react-document-title": "^2.0.3",
     "react-dom": "^15.3.1",
     "react-json-tree": "^0.10.9",
-    "react-pdf": "^2.0.0-alpha.7",
     "react-pdf-js": "^1.0.37",
+    "react-pdf": "^2.0.0-alpha.7",
     "react-redux": "^4.4.6",
     "react-responsive": "^1.3.0",
     "react-router": "^3.0.4",
+    "react-scripts": "^1.0.10",
     "react-table": "^6.5.1",
     "react-vega-lite": "^1.1.2",
-    "redux": "^3.6.0",
+    "react": "^15.6.1",
     "redux-logger": "^2.7.4",
+    "redux-mock-store": "^1.2.1",
     "redux-thunk": "^2.1.0",
+    "redux": "^3.6.0",
     "rss-parser": "^2.9.0",
     "traverse": "^0.6.6",
+    "typescript": "~2.4.0",
     "uuid": "^3.0.1",
-    "vega": "^3.0.0-rc2",
-    "vega-lite": "^2.0.0-beta.8"
+    "vega-lite": "^2.0.0-beta.8",
+    "vega": "^3.0.0-rc2"
   },
   "proxy": {
     "/server-config.js": {
       "target": "http://localhost:6107/"
     }
+  },
+  "config": {
+      "docker": {
+          "include": "node_modules build"
+      }
   }
 }

--- a/magda-web-server/package.json
+++ b/magda-web-server/package.json
@@ -16,7 +16,7 @@
     "@magda/scripts": "^0.0.29-SNAPSHOT",
     "@types/config": "0.0.32",
     "@types/express": "^4.0.35",
-    "@types/urijs": "^1.15.33",
+    "@types/urijs": "^1.15.34",
     "@types/yargs": "^6.6.0",
     "typescript": "~2.4.0"
   },
@@ -24,7 +24,7 @@
     "@magda/web-client": "^0.0.29-SNAPSHOT",
     "config": "^1.26.1",
     "express": "^4.15.3",
-    "urijs": "^1.18.10",
+    "urijs": "^1.18.12",
     "yargs": "^8.0.2"
   },
   "config": {

--- a/scripts/create-docker-context-for-node-component.js
+++ b/scripts/create-docker-context-for-node-component.js
@@ -206,7 +206,18 @@ function getPackageList(dependencies, basePath, result) {
             return;
         }
 
-        const dependencyDir = path.join(basePath, dependencyName.replace(/\//g, path.sep));
+        let dependencyDir = path.join(basePath, dependencyName.replace(/\//g, path.sep));
+
+        // Does this directory exist?  If not, imitate node's module resolution by walking
+        // up the directory tree.
+        while (!fse.existsSync(dependencyDir)) {
+            const upOne = path.resolve(dependencyDir, '..', '..', '..', path.basename(dependencyDir));
+            if (upOne === dependencyDir) {
+                break;
+            }
+            dependencyDir = upOne;
+        }
+
         result.push(dependencyDir);
 
         if (dependencyDetails.dependencies) {

--- a/scripts/create-docker-context-for-node-component.js
+++ b/scripts/create-docker-context-for-node-component.js
@@ -199,6 +199,10 @@ function prepareNodeModules(packageDir, destDir, productionPackages) {
 }
 
 function getPackageList(dependencies, basePath, result) {
+    if (!dependencies) {
+        return result;
+    }
+
     Object.keys(dependencies).forEach(function(dependencyName) {
         const dependencyDetails = dependencies[dependencyName];
         if (dependencyDetails.extraneous) {

--- a/scripts/create-docker-context-for-node-component.js
+++ b/scripts/create-docker-context-for-node-component.js
@@ -141,7 +141,12 @@ function preparePackage(packageDir, destDir, productionPackages) {
     if (!dockerIncludesFromPackageJson) {
         console.log(`WARNING: Package ${packageDir} does not have a config.docker.include key in package.json, so all of its files will be included in the docker image.`);
         dockerIncludes = fse.readdirSync(packageDir);
+    } else if (dockerIncludesFromPackageJson.trim() === '*') {
+        dockerIncludes = fse.readdirSync(packageDir);
     } else {
+        if (dockerIncludesFromPackageJson.indexOf('*') >= 0) {
+            throw new Error('Sorry, wildcards are not currently supported in config.docker.include.');
+        }
         dockerIncludes = dockerIncludesFromPackageJson.split(' ').filter(include => include.length > 0);
     }
 

--- a/scripts/create-docker-context-for-node-component.js
+++ b/scripts/create-docker-context-for-node-component.js
@@ -135,7 +135,15 @@ if (argv.build) {
 
 function preparePackage(packageDir, destDir, productionPackages) {
     const packageJson = require(path.join(packageDir, 'package.json'));
-    const dockerIncludes = (packageJson.config && packageJson.config.docker && packageJson.config.docker.include || '').split(' ').filter(include => include.length > 0);
+    const dockerIncludesFromPackageJson = packageJson.config && packageJson.config.docker && packageJson.config.docker.include;
+
+    let dockerIncludes;
+    if (!dockerIncludesFromPackageJson) {
+        console.log(`WARNING: Package ${packageDir} does not have a config.docker.include key in package.json, so all of its files will be included in the docker image.`);
+        dockerIncludes = fse.readdirSync(packageDir);
+    } else {
+        dockerIncludes = dockerIncludesFromPackageJson.split(' ').filter(include => include.length > 0);
+    }
 
     dockerIncludes.forEach(function(include) {
         const src = path.resolve(packageDir, include);

--- a/scripts/create-docker-context-for-node-component.js
+++ b/scripts/create-docker-context-for-node-component.js
@@ -214,7 +214,7 @@ function getPackageList(dependencies, basePath, result) {
         // Does this directory exist?  If not, imitate node's module resolution by walking
         // up the directory tree.
         while (!fse.existsSync(dependencyDir)) {
-            const upOne = path.resolve(dependencyDir, '..', '..', '..', path.basename(dependencyDir));
+            const upOne = path.resolve(dependencyDir, '..', '..', '..', 'node_modules', path.basename(dependencyDir));
             if (upOne === dependencyDir) {
                 break;
             }

--- a/scripts/create-docker-context-for-node-component.js
+++ b/scripts/create-docker-context-for-node-component.js
@@ -1,16 +1,12 @@
 #!/usr/bin/env node
 const childProcess = require('child_process');
 const fse = require('fs-extra');
+const klawSync = require("klaw-sync");
 const path = require('path');
 const process = require('process');
 const yargs = require('yargs');
 
 const argv = yargs.options({
-    include: {
-        description: 'The files and directories to include in the Docker image.  If not specified, uses the space-separated list in the `npm_package_config_docker_include` environment variable.',
-        default: (process.env.npm_package_config_docker_include || '').split(' '),
-        type: 'array'
-    },
     build: {
         description: 'Pipe the Docker context straight to Docker.',
         type: 'boolean',
@@ -49,38 +45,29 @@ fse.emptyDirSync(dockerContextDir);
 fse.ensureDirSync(componentDestDir);
 fse.ensureSymlinkSync(path.resolve(componentSrcDir, '..', 'node_modules'), path.resolve(dockerContextDir, 'node_modules'), 'junction');
 
-const linksToCreate = argv.include.filter((value, index, self) => self.indexOf(value) === index);
-linksToCreate.forEach(link => {
-    const src = path.resolve(componentSrcDir, link);
-    const dest = path.resolve(componentDestDir, link);
-    const type = fse.statSync(src).isFile() ? 'file' : 'junction'
+// Get the list of production packages.
+const productionPackageResult = JSON.parse(childProcess.spawnSync(
+    'npm', ['list', '--prod', '--json'],
+    { encoding: 'utf8', cwd: componentSrcDir, shell: true }).stdout);
+const productionPackages = getPackageList(productionPackageResult.dependencies, path.join(componentSrcDir, 'node_modules'), []);
 
-    // On Windows we can't create symlinks to files without special permissions.
-    // So just copy the file instead.  Usually creating directory junctions is
-    // fine without special permissions, but fall back on copying in the unlikely
-    // event that fails, too.
-    try {
-        fse.ensureSymlinkSync(src, dest, type);
-    } catch(e) {
-        fse.copySync(src, dest);
-    }
-});
+preparePackage(componentSrcDir, componentDestDir, productionPackages);
 
 const tar = process.platform === 'darwin' ? 'gtar' : 'tar';
 
-if (argv.build) {
-    // Docker and ConEmu (an otherwise excellent console for Windows) don't get along.
-    // See: https://github.com/Maximus5/ConEmu/issues/958 and https://github.com/moby/moby/issues/28814
-    // So if we're running under ConEmu, we need to add an extra -cur_console:i parameter to disable
-    // ConEmu's hooks and also set ConEmuANSI to OFF so Docker doesn't do anything drastic.
-    const env = Object.assign({}, process.env);
-    const extraParameters = [];
-    if (env.ConEmuANSI === 'ON') {
-        env.ConEmuANSI = 'OFF';
-        extraParameters.push('-cur_console:i');
-    }
+// Docker and ConEmu (an otherwise excellent console for Windows) don't get along.
+// See: https://github.com/Maximus5/ConEmu/issues/958 and https://github.com/moby/moby/issues/28814
+// So if we're running under ConEmu, we need to add an extra -cur_console:i parameter to disable
+// ConEmu's hooks and also set ConEmuANSI to OFF so Docker doesn't do anything drastic.
+const env = Object.assign({}, process.env);
+const extraParameters = [];
+if (env.ConEmuANSI === 'ON') {
+    env.ConEmuANSI = 'OFF';
+    extraParameters.push('-cur_console:i');
+}
 
-    const tarProcess = childProcess.spawn(tar, [...extraParameters, '--dereference', '-cf', '-', '*'], {
+if (argv.build) {
+    const tarProcess = childProcess.spawn(tar, [...extraParameters, '--dereference', '-czf', '-', '*'], {
         cwd: dockerContextDir,
         stdio: ['inherit', 'pipe', 'inherit'],
         env: env,
@@ -128,10 +115,104 @@ if (argv.build) {
         dockerProcess.stdin.write(data);
     });
 } else if (argv.output) {
-    console.log(path.resolve(process.cwd(), argv.output));
-    const tarProcess = childProcess.spawnSync(tar, ['--dereference', '-cf', argv.output, '*'], {
-        stdio: 'inherit'
+    const outputPath = path.resolve(process.cwd(), argv.output);
+    console.log(outputPath);
+
+    const outputTar = fse.openSync(outputPath, 'w', 0o644);
+
+    const tarProcess = childProcess.spawn(tar, ['--dereference', '-czf', '-', '*'], {
+        cwd: dockerContextDir,
+        stdio: ['inherit', outputTar, 'inherit'],
+        env: env,
+        shell: true
     });
-    console.log(tarProcess.status);
-    fse.removeSync(dockerContextDir);
+
+    tarProcess.on('close', code => {
+        fse.closeSync(outputTar);
+        console.log(tarProcess.status);
+        fse.removeSync(dockerContextDir);
+    });
+}
+
+function preparePackage(packageDir, destDir, productionPackages) {
+    const packageJson = require(path.join(packageDir, 'package.json'));
+    const dockerIncludes = (packageJson.config && packageJson.config.docker && packageJson.config.docker.include || '').split(' ').filter(include => include.length > 0);
+
+    dockerIncludes.forEach(function(include) {
+        const src = path.resolve(packageDir, include);
+        const dest = path.resolve(destDir, include);
+
+        if (include === 'node_modules') {
+            fse.ensureDirSync(dest);
+            prepareNodeModules(src, dest, productionPackages);
+            return;
+        }
+
+        const type = fse.statSync(src).isFile() ? 'file' : 'junction'
+
+        // On Windows we can't create symlinks to files without special permissions.
+        // So just copy the file instead.  Usually creating directory junctions is
+        // fine without special permissions, but fall back on copying in the unlikely
+        // event that fails, too.
+        try {
+            fse.ensureSymlinkSync(src, dest, type);
+        } catch(e) {
+            fse.copySync(src, dest);
+        }
+    });
+}
+
+function prepareNodeModules(packageDir, destDir, productionPackages) {
+    const subPackages = fse.readdirSync(packageDir);
+    subPackages.forEach(function(subPackageName) {
+        const src = path.join(packageDir, subPackageName);
+        const dest = path.join(destDir, subPackageName);
+
+        if (subPackageName[0] === '@') {
+            // This is a scope directory, recurse.
+            fse.ensureDirSync(dest);
+            prepareNodeModules(src, dest, productionPackages);
+            return;
+        }
+
+        if (productionPackages.indexOf(src) == -1) {
+            // Not a production dependency, skip it.
+            return;
+        }
+
+        const stat = fse.lstatSync(src);
+        if (stat.isSymbolicLink()) {
+            // This is a link to another package, presumably created by Lerna.
+            fse.ensureDirSync(dest);
+            preparePackage(src, dest, productionPackages);
+            return;
+        }
+
+
+        // Regular package, link/copy the whole thing.
+        try {
+            const type = stat.isFile() ? 'file' : 'junction'
+            fse.ensureSymlinkSync(src, dest, type);
+        } catch(e) {
+            fse.copySync(src, dest);
+        }
+    });
+}
+
+function getPackageList(dependencies, basePath, result) {
+    Object.keys(dependencies).forEach(function(dependencyName) {
+        const dependencyDetails = dependencies[dependencyName];
+        if (dependencyDetails.extraneous) {
+            return;
+        }
+
+        const dependencyDir = path.join(basePath, dependencyName.replace(/\//g, path.sep));
+        result.push(dependencyDir);
+
+        if (dependencyDetails.dependencies) {
+            getPackageList(dependencyDetails.dependencies, path.join(dependencyDir, 'node_modules'), result);
+        }
+    });
+
+    return result;
 }

--- a/scripts/create-docker-context-for-node-component.js
+++ b/scripts/create-docker-context-for-node-component.js
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 const childProcess = require('child_process');
 const fse = require('fs-extra');
-const klawSync = require("klaw-sync");
 const path = require('path');
 const process = require('process');
 const yargs = require('yargs');


### PR DESCRIPTION
With a few strategies:
* gzip the docker context before streaming it to docker.
* Only include `dependencies`, not `devDependencies`, of the package and its in-repo dependencies (e.g. `@magda/typescript-common`).
* Honor `config.docker.include` in `package.json` for in-repo dependencies.  For example, we don't need to include all of `@magda/typescript-common`, we only need its `dist` and `node_modules` directories.
