### PR TITLE
Fixed jsverify in ld sleuther tests

### DIFF
--- a/magda-sleuther-linked-data-rating/src/onRecordFound.ts
+++ b/magda-sleuther-linked-data-rating/src/onRecordFound.ts
@@ -10,78 +10,80 @@ import formatStars from "./openFormats";
 
 const openLicenseRegex = stringsToRegex(openLicenses);
 const openFormatRegexes = _(formatStars)
-  .mapValues(stringsToRegex)
-  .toPairs<RegExp>()
-  .map(([starCount, regex]) => [parseInt(starCount), regex] as [number, RegExp])
-  .sortBy(([starCount, regex]) => -1 * starCount)
-  .value();
-
-export default async function onRecordFound(
-  record: Record,
-  registryRetries: number = 5
-) {
-  const registry = getRegistry({ maxRetries: registryRetries });
-
-  const distributions = _(
-    record.aspects["dataset-distributions"]
-      ? record.aspects["dataset-distributions"].distributions
-      : []
-  )
-    .flatMap((distribution: Record) => distribution.aspects)
-    .flatMap((aspect: any) => aspect["dcat-distribution-strings"])
+    .mapValues(stringsToRegex)
+    .toPairs<RegExp>()
+    .map(
+        ([starCount, regex]) => [parseInt(starCount), regex] as [number, RegExp]
+    )
+    .sortBy(([starCount, regex]) => -1 * starCount)
     .value();
 
-  const processed = distributions.map(distribution => {
-    const isLicenseOpen = isOpenLicense(distribution.license);
+export default async function onRecordFound(
+    record: Record,
+    registryRetries: number = 5
+) {
+    const registry = getRegistry({ maxRetries: registryRetries });
 
-    if (isLicenseOpen) {
-      return Math.max(starsForFormat(distribution.format), 1);
-    } else {
-      return 0;
-    }
-  });
+    const distributions = _(
+        record.aspects["dataset-distributions"]
+            ? record.aspects["dataset-distributions"].distributions
+            : []
+    )
+        .flatMap((distribution: Record) => distribution.aspects)
+        .flatMap((aspect: any) => aspect["dcat-distribution-strings"])
+        .value();
 
-  const best = _.max(processed) || 0;
+    const processed = distributions.map(distribution => {
+        const isLicenseOpen = isOpenLicense(distribution.license);
 
-  const starsAspectPromise = registry
-    .putRecordAspect(record.id, linkedDataAspectDef.id, {
-      stars: best || 0
-    })
-    .then(result => unionToThrowable(result));
+        if (isLicenseOpen) {
+            return Math.max(starsForFormat(distribution.format), 1);
+        } else {
+            return 0;
+        }
+    });
 
-  const op = {
-    op: "add",
-    path: "/" + linkedDataAspectDef.id,
-    value: {
-      score: best / 5,
-      weighting: 0.8
-    }
-  };
+    const best = _.max(processed) || 0;
 
-  const qualityPromise = registry
-    .patchRecordAspect(record.id, datasetQualityAspectDef.id, [op])
-    .then(result => unionToThrowable(result));
+    const starsAspectPromise = registry
+        .putRecordAspect(record.id, linkedDataAspectDef.id, {
+            stars: best || 0
+        })
+        .then(result => unionToThrowable(result));
 
-  return Promise.all([starsAspectPromise, qualityPromise]).then(() => {});
+    const op = {
+        op: "add",
+        path: "/" + linkedDataAspectDef.id,
+        value: {
+            score: best / 5,
+            weighting: 0.8
+        }
+    };
+
+    const qualityPromise = registry
+        .patchRecordAspect(record.id, datasetQualityAspectDef.id, [op])
+        .then(result => unionToThrowable(result));
+
+    return Promise.all([starsAspectPromise, qualityPromise]).then(() => {});
 }
 
 function isOpenLicense(license: string): boolean {
-  return openLicenseRegex.test(license);
+    return openLicenseRegex.test(license);
 }
 
 function starsForFormat(format: string): number {
-  const starRatingForFormat = _(openFormatRegexes)
-    .filter(([starCount, regex]) => regex.test(format))
-    .map(([starCount, regex]) => starCount)
-    .first();
+    const starRatingForFormat = _(openFormatRegexes)
+        .filter(([starCount, regex]) => regex.test(format))
+        .map(([starCount, regex]) => starCount)
+        .first();
 
-  return starRatingForFormat || 0;
+    return starRatingForFormat || 0;
 }
 
 function stringsToRegex(array: string[]): RegExp {
-  function regexIfy(string: string) {
-    return string.replace(/[^a-zA-Z\d]/g, "[\\s\\S]*");
-  }
+    function regexIfy(string: string) {
+        return string.replace(/[^a-zA-Z\d]/g, "[\\s\\S]*");
+    }
 
-  return new RegExp(array.map(regexIfy).join("|"), "i");
+    return new RegExp(array.map(regexIfy).join("|"), "i");
 }


### PR DESCRIPTION
Unfortunately there's a bunch of indentation changes here mixed in.

Essentially this prevents build failures like https://travis-ci.org/TerriaJS/magda/jobs/274899356

The property tests were generating formats like "gpxls" which could be interpreted as both a 3 star or a 2 star dataset, this improves the check regex to make sure they're unambiguous.