### PR TITLE
Don't trust npm ls to be correct for linked dependencies.

### DIFF
--- a/magda-web-client/src/Components/Admin/Connectors.js
+++ b/magda-web-client/src/Components/Admin/Connectors.js
@@ -1,6 +1,5 @@
 import React from "react";
 import { connect } from "react-redux";
-import { Link } from "react-router";
 import { bindActionCreators } from "redux";
 import Login from "../Account/Login";
 


### PR DESCRIPTION
Instead, get each package's dependencies independently.

@AlexGilleran this should fix the problem with `request` missing in `sleuther-linked-data-rating`.