### PR TITLE
Fix admin api namespaces

### DIFF
--- a/magda-admin-api/src/buildApiRouter.ts
+++ b/magda-admin-api/src/buildApiRouter.ts
@@ -11,13 +11,14 @@ export interface Options {
     kubernetesApiType: K8SApiType;
     registryApiUrl: string;
     pullPolicy: string;
+    namespace?: string;
 }
 
 export default function buildApiRouter(options: Options) {
     const router: express.Router = express.Router();
     const prefixId = (id: string) => `connector-${id}`;
 
-    const k8sApi = new K8SApi(options.kubernetesApiType);
+    const k8sApi = new K8SApi(options.kubernetesApiType, options.namespace);
 
     router.use(mustBeAdmin(options.authApiUrl));
 

--- a/magda-admin-api/src/k8sApi.ts
+++ b/magda-admin-api/src/k8sApi.ts
@@ -63,9 +63,7 @@ export default class K8SApi {
     }
 
     getConnectorConfigMap() {
-        return promisify(
-            this.configMaps.get.bind(this.configMaps)
-        )({
+        return promisify(this.configMaps.get.bind(this.configMaps))({
             name: "connector-config"
         }).then((result: any) =>
             _(result.data)
@@ -78,13 +76,12 @@ export default class K8SApi {
     }
 
     updateConnectorConfigMap(id: string, newConfig: any) {
-        return promisify(
-            this.configMaps.patch.bind(this.configMaps)
-        )({
+        return promisify(this.configMaps.patch.bind(this.configMaps))({
             name: "connector-config",
             body: {
                 data: {
-                    [`${id}.json`]: newConfig && JSON.stringify(newConfig)
+                    [`${id}.json`]:
+                        newConfig && JSON.stringify(newConfig, null, 2)
                 }
             }
         });

--- a/magda-admin-api/src/k8sApi.ts
+++ b/magda-admin-api/src/k8sApi.ts
@@ -11,45 +11,34 @@ import getMinikubeIP from "@magda/typescript-common/dist/util/getMinikubeIP";
 export type K8SApiType = "minikube" | "cluster" | "test";
 
 export default class K8SApi {
-    private batchApi: any;
-    private coreApi: any;
+    private jobs: any;
+    private configMaps: any;
+    private getJobsInner: any;
 
     constructor(apiType: K8SApiType, private namespace: string = "default") {
         const details = K8SApi.getDetails(apiType);
-        this.batchApi = new Api.Batch(details);
-        this.coreApi = new Api.Core(details);
+        const batchApi = new Api.Batch(details);
+        this.jobs = batchApi.ns(this.namespace).jobs;
+        this.getJobsInner = promisify(this.jobs.get.bind(this.jobs));
+
+        const coreApi = new Api.Core(details);
+        this.configMaps = coreApi.ns(this.namespace).configmaps;
     }
 
     getJobs(): Promise<any> {
-        return promisify(
-            this.batchApi
-                .ns(this.namespace)
-                .jobs.get.bind(this.batchApi.ns.jobs)
-        )();
+        return this.getJobsInner();
     }
 
     getJobStatus(id: string): Promise<any> {
-        return promisify(
-            this.batchApi
-                .ns(this.namespace)
-                .jobs.get.bind(this.batchApi.ns.jobs)
-        )({ name: `${id}/status` });
+        return this.getJobsInner({ name: `${id}/status` });
     }
 
     createJob(body: any): Promise<any> {
-        return promisify(
-            this.batchApi
-                .ns(this.namespace)
-                .jobs.post.bind(this.batchApi.ns.jobs)
-        )({ body });
+        return promisify(this.jobs.post.bind(this.jobs))({ body });
     }
 
     deleteJob(id: string) {
-        return promisify(
-            this.batchApi
-                .ns(this.namespace)
-                .jobs.delete.bind(this.batchApi.ns.jobs)
-        )({
+        return promisify(this.jobs.delete.bind(this.jobs))({
             name: id,
             body: {
                 kind: "DeleteOptions",
@@ -75,7 +64,7 @@ export default class K8SApi {
 
     getConnectorConfigMap() {
         return promisify(
-            this.coreApi.ns.configmaps.get.bind(this.coreApi.ns.configmaps)
+            this.configMaps.get.bind(this.configMaps)
         )({
             name: "connector-config"
         }).then((result: any) =>
@@ -90,7 +79,7 @@ export default class K8SApi {
 
     updateConnectorConfigMap(id: string, newConfig: any) {
         return promisify(
-            this.coreApi.ns.configmaps.patch.bind(this.coreApi.ns.configmaps)
+            this.configMaps.patch.bind(this.configMaps)
         )({
             name: "connector-config",
             body: {

--- a/magda-admin-api/src/test/buildApiRouter.spec.ts
+++ b/magda-admin-api/src/test/buildApiRouter.spec.ts
@@ -207,7 +207,7 @@ describe("admin api router", function(this: Mocha.ISuiteCallbackContext) {
 
         it("should put a new entry in the k8s connector-config configmap", () => {
             const expectedConfigMap = {
-                [`${name}.json`]: JSON.stringify(connectorConfig)
+                [`${name}.json`]: JSON.stringify(connectorConfig, null, 2)
             };
 
             k8sApiScope
@@ -502,7 +502,12 @@ describe("admin api router", function(this: Mocha.ISuiteCallbackContext) {
 
                 it("if getting connector config fails", () => {
                     helpers.mockJobStatus(k8sApiScope, 404, name, namespace);
-                    helpers.mockConnectorConfig(k8sApiScope, 500, namespace, null);
+                    helpers.mockConnectorConfig(
+                        k8sApiScope,
+                        500,
+                        namespace,
+                        null
+                    );
                     helpers.mockCreateJob(
                         k8sApiScope,
                         200,

--- a/magda-admin-api/src/test/buildApiRouter.spec.ts
+++ b/magda-admin-api/src/test/buildApiRouter.spec.ts
@@ -13,6 +13,7 @@ import { stateArb } from "./arbitraries";
 
 describe("admin api router", function(this: Mocha.ISuiteCallbackContext) {
     this.timeout(10000);
+    const namespace = "THISISANAMESPACE";
     let app: express.Express;
     let k8sApiScope: nock.Scope;
 
@@ -35,8 +36,13 @@ describe("admin api router", function(this: Mocha.ISuiteCallbackContext) {
             return jsc.assert(
                 jsc.forall(stateArb, state => {
                     beforeEachInner();
-                    helpers.mockConnectorConfig(k8sApiScope, 200, state);
-                    helpers.mockJobs(k8sApiScope, 200, state);
+                    helpers.mockConnectorConfig(
+                        k8sApiScope,
+                        200,
+                        namespace,
+                        state
+                    );
+                    helpers.mockJobs(k8sApiScope, 200, namespace, state);
 
                     return helpers
                         .getConnectors(app)
@@ -105,11 +111,13 @@ describe("admin api router", function(this: Mocha.ISuiteCallbackContext) {
                     helpers.mockConnectorConfig(
                         k8sApiScope,
                         200,
+                        namespace,
                         helpers.getStateForStatus(status)
                     );
                     helpers.mockJobs(
                         k8sApiScope,
                         200,
+                        namespace,
                         helpers.getStateForStatus(status)
                     );
                     return assertStatus(status);
@@ -121,11 +129,13 @@ describe("admin api router", function(this: Mocha.ISuiteCallbackContext) {
                     helpers.mockConnectorConfig(
                         k8sApiScope,
                         200,
+                        namespace,
                         helpers.getStateForStatus(status)
                     );
                     helpers.mockJobs(
                         k8sApiScope,
                         200,
+                        namespace,
                         helpers.getStateForStatus(status)
                     );
                     return assertStatus("inactive");
@@ -160,18 +170,23 @@ describe("admin api router", function(this: Mocha.ISuiteCallbackContext) {
                 const state = helpers.getBasicState();
 
                 it("a failure to get jobs", () => {
-                    helpers.mockConnectorConfig(k8sApiScope, 200, state);
-                    helpers.mockJobs(k8sApiScope, 500);
+                    helpers.mockConnectorConfig(
+                        k8sApiScope,
+                        200,
+                        namespace,
+                        state
+                    );
+                    helpers.mockJobs(k8sApiScope, 500, namespace);
                 });
 
                 it("a failure to get connector config", () => {
-                    helpers.mockConnectorConfig(k8sApiScope, 500);
-                    helpers.mockJobs(k8sApiScope, 200, state);
+                    helpers.mockConnectorConfig(k8sApiScope, 500, namespace);
+                    helpers.mockJobs(k8sApiScope, 200, namespace, state);
                 });
 
                 it("a failure to get both", () => {
-                    helpers.mockConnectorConfig(k8sApiScope, 500);
-                    helpers.mockJobs(k8sApiScope, 500);
+                    helpers.mockConnectorConfig(k8sApiScope, 500, namespace);
+                    helpers.mockJobs(k8sApiScope, 500, namespace);
                 });
 
                 afterEach(() => {
@@ -197,7 +212,7 @@ describe("admin api router", function(this: Mocha.ISuiteCallbackContext) {
 
             k8sApiScope
                 .patch(
-                    "/api/v1/namespaces/default/configmaps/connector-config",
+                    `/api/v1/namespaces/${namespace}/configmaps/connector-config`,
                     {
                         data: expectedConfigMap
                     }
@@ -217,7 +232,7 @@ describe("admin api router", function(this: Mocha.ISuiteCallbackContext) {
             it("should return 500 if k8s call doesn't work", () => {
                 k8sApiScope
                     .patch(
-                        "/api/v1/namespaces/default/configmaps/connector-config",
+                        `/api/v1/namespaces/${namespace}/configmaps/connector-config`,
                         () => true
                     )
                     .reply(500, "Oh noes");
@@ -263,14 +278,14 @@ describe("admin api router", function(this: Mocha.ISuiteCallbackContext) {
 
                 k8sApiScope
                     .patch(
-                        "/api/v1/namespaces/default/configmaps/connector-config",
+                        `/api/v1/namespaces/${namespace}/configmaps/connector-config`,
                         {
                             data: expectedConfigMap
                         }
                     )
                     .reply(200, expectedConfigMap);
 
-                helpers.mockJobStatus(k8sApiScope, 404, name);
+                helpers.mockJobStatus(k8sApiScope, 404, name, namespace);
 
                 return helpers.deleteConnector(app, name).then(res => {
                     expect(res.status).to.equal(200);
@@ -288,12 +303,13 @@ describe("admin api router", function(this: Mocha.ISuiteCallbackContext) {
                     k8sApiScope,
                     200,
                     name,
+                    namespace,
                     helpers.getBasicState(name)
                 );
-                helpers.mockDeleteJob(k8sApiScope, 200, name);
+                helpers.mockDeleteJob(k8sApiScope, 200, name, namespace);
                 k8sApiScope
                     .patch(
-                        "/api/v1/namespaces/default/configmaps/connector-config",
+                        `/api/v1/namespaces/${namespace}/configmaps/connector-config`,
                         {
                             data: expectedConfigMap
                         }
@@ -311,10 +327,10 @@ describe("admin api router", function(this: Mocha.ISuiteCallbackContext) {
         silenceErrorLogs(() => {
             describe("should return 500", () => {
                 it("when patch config map call doesn't work", () => {
-                    helpers.mockJobStatus(k8sApiScope, 404, name);
+                    helpers.mockJobStatus(k8sApiScope, 404, name, namespace);
                     k8sApiScope
                         .patch(
-                            "/api/v1/namespaces/default/configmaps/connector-config",
+                            `/api/v1/namespaces/${namespace}/configmaps/connector-config`,
                             () => true
                         )
                         .reply(500, "Oh noes");
@@ -327,10 +343,10 @@ describe("admin api router", function(this: Mocha.ISuiteCallbackContext) {
                 });
 
                 it("when get jobs status call doesn't work", () => {
-                    helpers.mockJobStatus(k8sApiScope, 500, name);
+                    helpers.mockJobStatus(k8sApiScope, 500, name, namespace);
                     k8sApiScope
                         .patch(
-                            "/api/v1/namespaces/default/configmaps/connector-config",
+                            `/api/v1/namespaces/${namespace}/configmaps/connector-config`,
                             () => true
                         )
                         .optionally()
@@ -347,12 +363,13 @@ describe("admin api router", function(this: Mocha.ISuiteCallbackContext) {
                         k8sApiScope,
                         200,
                         name,
+                        namespace,
                         helpers.getBasicState(name)
                     );
-                    helpers.mockDeleteJob(k8sApiScope, 500, name);
+                    helpers.mockDeleteJob(k8sApiScope, 500, name, namespace);
                     k8sApiScope
                         .patch(
-                            "/api/v1/namespaces/default/configmaps/connector-config",
+                            `/api/v1/namespaces/${namespace}/configmaps/connector-config`,
                             () => true
                         )
                         .optionally()
@@ -393,9 +410,14 @@ describe("admin api router", function(this: Mocha.ISuiteCallbackContext) {
             const tag = "latest";
             const app = buildExpressApp(tag);
             const connectorState = helpers.getStateForStatus("active", name);
-            helpers.mockJobStatus(k8sApiScope, 404, name);
-            helpers.mockConnectorConfig(k8sApiScope, 200, connectorState);
-            helpers.mockCreateJob(k8sApiScope, 200, (body: any) => {
+            helpers.mockJobStatus(k8sApiScope, 404, name, namespace);
+            helpers.mockConnectorConfig(
+                k8sApiScope,
+                200,
+                namespace,
+                connectorState
+            );
+            helpers.mockCreateJob(k8sApiScope, 200, namespace, (body: any) => {
                 const metadataMatch = (metadata: any) =>
                     metadata.name === `connector-${name}` &&
                     metadata.magdaSleuther === true;
@@ -438,11 +460,17 @@ describe("admin api router", function(this: Mocha.ISuiteCallbackContext) {
                 k8sApiScope,
                 200,
                 name,
+                namespace,
                 helpers.getBasicState(name)
             );
-            helpers.mockDeleteJob(k8sApiScope, 200, name);
-            helpers.mockConnectorConfig(k8sApiScope, 200, connectorState);
-            helpers.mockCreateJob(k8sApiScope, 200);
+            helpers.mockDeleteJob(k8sApiScope, 200, name, namespace);
+            helpers.mockConnectorConfig(
+                k8sApiScope,
+                200,
+                namespace,
+                connectorState
+            );
+            helpers.mockCreateJob(k8sApiScope, 200, namespace);
             return helpers.startConnector(app, name, true).then(res => {
                 expect(res.status).to.equal(200);
             });
@@ -451,14 +479,21 @@ describe("admin api router", function(this: Mocha.ISuiteCallbackContext) {
         silenceErrorLogs(() => {
             describe("should return 500", () => {
                 it("if getting existing job status fails", () => {
-                    helpers.mockJobStatus(k8sApiScope, 500, name);
+                    helpers.mockJobStatus(k8sApiScope, 500, name, namespace);
                     helpers.mockConnectorConfig(
                         k8sApiScope,
                         200,
+                        namespace,
                         helpers.getStateForStatus("active", name),
                         true
                     );
-                    helpers.mockCreateJob(k8sApiScope, 200, () => true, true);
+                    helpers.mockCreateJob(
+                        k8sApiScope,
+                        200,
+                        namespace,
+                        () => true,
+                        true
+                    );
 
                     return helpers.startConnector(app, name, true).then(res => {
                         expect(res.status).to.equal(500);
@@ -466,9 +501,15 @@ describe("admin api router", function(this: Mocha.ISuiteCallbackContext) {
                 });
 
                 it("if getting connector config fails", () => {
-                    helpers.mockJobStatus(k8sApiScope, 404, name);
-                    helpers.mockConnectorConfig(k8sApiScope, 500, null);
-                    helpers.mockCreateJob(k8sApiScope, 200, () => true, true);
+                    helpers.mockJobStatus(k8sApiScope, 404, name, namespace);
+                    helpers.mockConnectorConfig(k8sApiScope, 500, namespace, null);
+                    helpers.mockCreateJob(
+                        k8sApiScope,
+                        200,
+                        namespace,
+                        () => true,
+                        true
+                    );
 
                     return helpers.startConnector(app, name, true).then(res => {
                         expect(res.status).to.equal(500);
@@ -484,16 +525,24 @@ describe("admin api router", function(this: Mocha.ISuiteCallbackContext) {
                         k8sApiScope,
                         200,
                         name,
+                        namespace,
                         connectorState
                     );
-                    helpers.mockDeleteJob(k8sApiScope, 500, name);
+                    helpers.mockDeleteJob(k8sApiScope, 500, name, namespace);
                     helpers.mockConnectorConfig(
                         k8sApiScope,
                         200,
+                        namespace,
                         connectorState,
                         true
                     );
-                    helpers.mockCreateJob(k8sApiScope, 200, () => true, true);
+                    helpers.mockCreateJob(
+                        k8sApiScope,
+                        200,
+                        namespace,
+                        () => true,
+                        true
+                    );
 
                     return helpers.startConnector(app, name, true).then(res => {
                         expect(res.status).to.equal(500);
@@ -509,15 +558,22 @@ describe("admin api router", function(this: Mocha.ISuiteCallbackContext) {
                         k8sApiScope,
                         200,
                         name,
+                        namespace,
                         connectorState
                     );
-                    helpers.mockDeleteJob(k8sApiScope, 200, name);
+                    helpers.mockDeleteJob(k8sApiScope, 200, name, namespace);
                     helpers.mockConnectorConfig(
                         k8sApiScope,
                         200,
+                        namespace,
                         connectorState
                     );
-                    helpers.mockCreateJob(k8sApiScope, 500, () => true);
+                    helpers.mockCreateJob(
+                        k8sApiScope,
+                        500,
+                        namespace,
+                        () => true
+                    );
 
                     return helpers.startConnector(app, name, true).then(res => {
                         expect(res.status).to.equal(500);
@@ -531,13 +587,20 @@ describe("admin api router", function(this: Mocha.ISuiteCallbackContext) {
                         "active",
                         "otherJob"
                     );
-                    helpers.mockJobStatus(k8sApiScope, 404, name);
+                    helpers.mockJobStatus(k8sApiScope, 404, name, namespace);
                     helpers.mockConnectorConfig(
                         k8sApiScope,
                         200,
+                        namespace,
                         connectorState
                     );
-                    helpers.mockCreateJob(k8sApiScope, 200, () => true, true);
+                    helpers.mockCreateJob(
+                        k8sApiScope,
+                        200,
+                        namespace,
+                        () => true,
+                        true
+                    );
 
                     return helpers.startConnector(app, name, true).then(res => {
                         expect(res.status).to.equal(404);
@@ -569,7 +632,7 @@ describe("admin api router", function(this: Mocha.ISuiteCallbackContext) {
         const name = "test";
 
         it("should stop a currently running job", () => {
-            helpers.mockDeleteJob(k8sApiScope, 200, name);
+            helpers.mockDeleteJob(k8sApiScope, 200, name, namespace);
 
             return helpers.stopConnector(app, name).then(res => {
                 expect(res.status).to.equal(204);
@@ -578,7 +641,7 @@ describe("admin api router", function(this: Mocha.ISuiteCallbackContext) {
 
         silenceErrorLogs(() => {
             it("should return 404 for a non-running job", () => {
-                helpers.mockDeleteJob(k8sApiScope, 404, name);
+                helpers.mockDeleteJob(k8sApiScope, 404, name, namespace);
 
                 return helpers.stopConnector(app, name).then(res => {
                     expect(res.status).to.equal(404);
@@ -586,7 +649,7 @@ describe("admin api router", function(this: Mocha.ISuiteCallbackContext) {
             });
 
             it("should return 500 if the kubernetes delete job fails", () => {
-                helpers.mockDeleteJob(k8sApiScope, 500, name);
+                helpers.mockDeleteJob(k8sApiScope, 500, name, namespace);
 
                 return helpers.stopConnector(app, name).then(res => {
                     expect(res.status).to.equal(500);
@@ -634,7 +697,8 @@ describe("admin api router", function(this: Mocha.ISuiteCallbackContext) {
             imageTag,
             kubernetesApiType: "test",
             registryApiUrl: "http://registry.example.com",
-            pullPolicy: "pullPolicy"
+            pullPolicy: "pullPolicy",
+            namespace
         });
 
         const app = express();

--- a/magda-admin-api/src/test/helpers.ts
+++ b/magda-admin-api/src/test/helpers.ts
@@ -44,11 +44,12 @@ export function getStateForStatus(
 export function mockConnectorConfig(
     k8sApiScope: nock.Scope,
     statusCode: number,
+    namespace: string,
     state?: State,
     optionally: boolean = false
 ) {
     const req = k8sApiScope.get(
-        "/api/v1/namespaces/default/configmaps/connector-config"
+        `/api/v1/namespaces/${namespace}/configmaps/connector-config`
     );
 
     if (optionally) {
@@ -69,9 +70,10 @@ export function mockConnectorConfig(
 export function mockJobs(
     k8sApiScope: nock.Scope,
     statusCode: number,
+    namespace: string,
     state?: State
 ) {
-    k8sApiScope.get("/apis/batch/v1/namespaces/default/jobs").reply(
+    k8sApiScope.get(`/apis/batch/v1/namespaces/${namespace}/jobs`).reply(
         statusCode,
         statusCode === 200
             ? fixtures.getJobs(_(state)
@@ -85,11 +87,12 @@ export function mockJobStatus(
     k8sApiScope: nock.Scope,
     statusCode: number,
     name: string,
+    namespace: string,
     state?: State,
     optionally: boolean = false
 ) {
     const req = k8sApiScope.get(
-        `/apis/batch/v1/namespaces/default/jobs/connector-${name}/status`
+        `/apis/batch/v1/namespaces/${namespace}/jobs/connector-${name}/status`
     );
 
     if (optionally) {
@@ -137,10 +140,11 @@ export function deleteConnector(
 export function mockDeleteJob(
     k8sApiScope: nock.Scope,
     statusCode: number,
-    id: string
+    id: string,
+    namespace: string
 ) {
     k8sApiScope
-        .delete(`/apis/batch/v1/namespaces/default/jobs/connector-${id}`, {
+        .delete(`/apis/batch/v1/namespaces/${namespace}/jobs/connector-${id}`, {
             kind: "DeleteOptions",
             apiVersion: "batch/v1",
             propagationPolicy: "Background"
@@ -153,11 +157,12 @@ export function mockDeleteJob(
 export function mockCreateJob(
     k8sApiScope: nock.Scope,
     statusCode: number,
+    namespace: string,
     body?: any,
     optionally: boolean = false
 ) {
     const req = k8sApiScope.post(
-        `/apis/batch/v1/namespaces/default/jobs`,
+        `/apis/batch/v1/namespaces/${namespace}/jobs`,
         body
     );
 


### PR DESCRIPTION
- Tests now look for a non-default namespace in admin api.
- Also made the admin api add prettified json to the connector-config configmap so it's easier to read through kubectl.