### PR TITLE
Corrected references to refer to sleuther-broken-link

### DIFF
--- a/deploy/helm/magda/charts/sleuther-broken-link/templates/service.yaml
+++ b/deploy/helm/magda/charts/sleuther-broken-link/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: sleuther-linked-data-rating
+  name: sleuther-broken-link
 spec:
   ports:
   - name: http
@@ -12,4 +12,4 @@ spec:
   type: NodePort
 {{- end }}
   selector:
-    service: sleuther-linked-data-rating
+    service: sleuther-broken-link


### PR DESCRIPTION
Helm deployment was failing because the sleuther-broken-link service.yaml template incorrectly referred to sleuther-linked-data-rating resulting an error because that service name had already been used.  