### PR TITLE
Generate a sitemap that includes all the dataset files

### DIFF
--- a/deploy/helm/magda/charts/web-server/templates/deployment.yaml
+++ b/deploy/helm/magda/charts/web-server/templates/deployment.yaml
@@ -16,8 +16,10 @@ spec:
       - name: web
         command: [
             "node", "/usr/src/app/component/dist/index.js",
-            "--config", "/etc/config.json",
-            "--listenPort", "80"
+            "--config", "/etc/config/config.json",
+            "--listenPort", "80",
+            "--baseExternalUrl", {{ .Values.global.externalUrl | quote }},
+            "--registryApiBaseUrlInternal", "http://registry-api/v0"
         ]
         resources:
 {{ toYaml .Values.resources | indent 10 }}
@@ -27,7 +29,7 @@ spec:
         image: {{ template "dockerimage" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy | default .Values.global.image.pullPolicy }}
         volumeMounts:
-        - mountPath: "/etc"
+        - mountPath: "/etc/config"
           name: config
       volumes:
       - name: config

--- a/deploy/helm/minikube-dev.yml
+++ b/deploy/helm/minikube-dev.yml
@@ -1,5 +1,5 @@
 global:
-  externalUrl: http://minikube.data.gov.au:30016
+  externalUrl: http://minikube.data.gov.au:30100
   rollingUpdate:
     maxUnavailable: 1
   exposeNodePorts: true

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordsService.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordsService.scala
@@ -58,7 +58,7 @@ class RecordsService(config: Config, webHookActor: ActorRef, authClient: AuthApi
   @ApiOperation(value = "Get a list tokens for paging through the records", nickname = "getPageTokens", httpMethod = "GET", response = classOf[String], responseContainer = "List")
   @ApiImplicitParams(Array(
     new ApiImplicitParam(name = "aspect", required = false, dataType = "string", paramType = "query", allowMultiple = true, value = "The aspects for which to retrieve data, specified as multiple occurrences of this query parameter.  Only records that have all of these aspects will be included in the response."),
-    new ApiImplicitParam(name = "limit", required = false, dataType = "number", paramType = "query", value = "The maximum number of records to receive.  The response will include a token that can be passed as the pageToken parameter to a future request to continue receiving results where this query leaves off.")))
+    new ApiImplicitParam(name = "limit", required = false, dataType = "number", paramType = "query", value = "The size of each page to get tokens for.")))
   def getPageTokens = get {
     path("pagetokens") {
       pathEnd {

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordsService.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordsService.scala
@@ -65,7 +65,7 @@ class RecordsService(config: Config, webHookActor: ActorRef, authClient: AuthApi
         parameters('aspect.*, 'limit.as[Int].?) { (aspect, limit) =>
           complete {
             DB readOnly { session =>
-              RecordPersistence.getPageTokens(session, aspect, limit)
+              "0" :: RecordPersistence.getPageTokens(session, aspect, limit)
             }
           }
         }

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordsService.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordsService.scala
@@ -54,20 +54,19 @@ class RecordsService(config: Config, webHookActor: ActorRef, authClient: AuthApi
     }
   }
 
+  @Path("/pagetokens")
   @ApiOperation(value = "Get a list tokens for paging through the records", nickname = "getPageTokens", httpMethod = "GET", response = classOf[String], responseContainer = "List")
   @ApiImplicitParams(Array(
     new ApiImplicitParam(name = "aspect", required = false, dataType = "string", paramType = "query", allowMultiple = true, value = "The aspects for which to retrieve data, specified as multiple occurrences of this query parameter.  Only records that have all of these aspects will be included in the response."),
-    new ApiImplicitParam(name = "optionalAspect", required = false, dataType = "string", paramType = "query", allowMultiple = true, value = "The optional aspects for which to retrieve data, specified as multiple occurrences of this query parameter.  These aspects will be included in a record if available, but a record will be included even if it is missing these aspects."),
-    new ApiImplicitParam(name = "pageToken", required = false, dataType = "string", paramType = "query", value = "A token that identifies the start of a page of results.  This token should not be interpreted as having any meaning, but it can be obtained from a previous page of results."),
-    new ApiImplicitParam(name = "start", required = false, dataType = "number", paramType = "query", value = "The index of the first record to retrieve.  When possible, specify pageToken instead as it will result in better performance.  If this parameter and pageToken are both specified, this parameter is interpreted as the index after the pageToken of the first record to retrieve."),
-    new ApiImplicitParam(name = "limit", required = false, dataType = "number", paramType = "query", value = "The maximum number of records to receive.  The response will include a token that can be passed as the pageToken parameter to a future request to continue receiving results where this query leaves off."),
-    new ApiImplicitParam(name = "dereference", required = false, dataType = "boolean", paramType = "query", value = "true to automatically dereference links to other records; false to leave them as links.  Dereferencing a link means including the record itself where the link would be.  Dereferencing only happens one level deep, regardless of the value of this parameter.")))
+    new ApiImplicitParam(name = "limit", required = false, dataType = "number", paramType = "query", value = "The maximum number of records to receive.  The response will include a token that can be passed as the pageToken parameter to a future request to continue receiving results where this query leaves off.")))
   def getPageTokens = get {
     path("pagetokens") {
-      parameters('aspect.*, 'limit.as[Int].?) { (aspect, limit) =>
-        complete {
-          DB readOnly { session =>
-            RecordPersistence.getPageTokens(session, aspect, limit)
+      pathEnd {
+        parameters('aspect.*, 'limit.as[Int].?) { (aspect, limit) =>
+          complete {
+            DB readOnly { session =>
+              RecordPersistence.getPageTokens(session, aspect, limit)
+            }
           }
         }
       }

--- a/magda-typescript-common/src/generated/registry/api.ts
+++ b/magda-typescript-common/src/generated/registry/api.ts
@@ -1352,6 +1352,61 @@ export class RecordsApi {
         });
     }
     /**
+     * Get a list tokens for paging through the records
+     * 
+     * @param aspect The aspects for which to retrieve data, specified as multiple occurrences of this query parameter.  Only records that have all of these aspects will be included in the response.
+     * @param limit The maximum number of records to receive.  The response will include a token that can be passed as the pageToken parameter to a future request to continue receiving results where this query leaves off.
+     */
+    public getPageTokens (aspect?: Array<string>, limit?: number) : Promise<{ response: http.IncomingMessage; body: Array<string>;  }> {
+        const localVarPath = this.basePath + '/records/pagetokens';
+        let queryParameters: any = {};
+        let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
+        let formParams: any = {};
+
+
+        if (aspect !== undefined) {
+            queryParameters['aspect'] = aspect;
+        }
+
+        if (limit !== undefined) {
+            queryParameters['limit'] = limit;
+        }
+
+        let useFormData = false;
+
+        let requestOptions: request.Options = {
+            method: 'GET',
+            qs: queryParameters,
+            headers: headerParams,
+            uri: localVarPath,
+            useQuerystring: this._useQuerystring,
+            json: true,
+        };
+
+        this.authentications.default.applyToRequest(requestOptions);
+
+        if (Object.keys(formParams).length) {
+            if (useFormData) {
+                (<any>requestOptions).formData = formParams;
+            } else {
+                requestOptions.form = formParams;
+            }
+        }
+        return new Promise<{ response: http.IncomingMessage; body: Array<string>;  }>((resolve, reject) => {
+            request(requestOptions, (error, response, body) => {
+                if (error) {
+                    reject(error);
+                } else {
+                    if (response.statusCode >= 200 && response.statusCode <= 299) {
+                        resolve({ response: response, body: body });
+                    } else {
+                        reject({ response: response, body: body });
+                    }
+                }
+            });
+        });
+    }
+    /**
      * Modify a record by applying a JSON Patch
      * The patch should follow IETF RFC 6902 (https://tools.ietf.org/html/rfc6902).
      * @param id ID of the aspect to be saved.

--- a/magda-typescript-common/src/registry/RegistryClient.ts
+++ b/magda-typescript-common/src/registry/RegistryClient.ts
@@ -1,10 +1,10 @@
 import {
-  AspectDefinition,
-  AspectDefinitionsApi,
-  Record,
-  RecordsApi,
-  RecordAspectsApi,
-  WebHooksApi
+    AspectDefinition,
+    AspectDefinitionsApi,
+    Record,
+    RecordsApi,
+    RecordAspectsApi,
+    WebHooksApi
 } from "../generated/registry/api";
 import * as URI from "urijs";
 import retry from "../retry";
@@ -12,118 +12,144 @@ import formatServiceError from "../formatServiceError";
 import createServiceError from "../createServiceError";
 
 export interface RegistryOptions {
-  baseUrl: string;
-  maxRetries?: number;
-  secondsBetweenRetries?: number;
+    baseUrl: string;
+    maxRetries?: number;
+    secondsBetweenRetries?: number;
 }
 
 export interface PutResult {
-  successfulPuts: number;
-  errors: Error[];
+    successfulPuts: number;
+    errors: Error[];
 }
 
-export interface RecordsPage<I> {
-  totalCount: number;
-  nextPageToken?: string;
-  records: I[];
+export interface RecordsPage<I extends Record> {
+    totalCount: number;
+    nextPageToken?: string;
+    records: I[];
 }
 
 export default class RegistryClient {
-  protected baseUri: uri.URI;
-  protected aspectDefinitionsApi: AspectDefinitionsApi;
-  protected recordsApi: RecordsApi;
-  protected webHooksApi: WebHooksApi;
-  protected recordAspectsApi: RecordAspectsApi;
-  protected maxRetries: number;
-  protected secondsBetweenRetries: number;
+    protected baseUri: uri.URI;
+    protected aspectDefinitionsApi: AspectDefinitionsApi;
+    protected recordsApi: RecordsApi;
+    protected webHooksApi: WebHooksApi;
+    protected recordAspectsApi: RecordAspectsApi;
+    protected maxRetries: number;
+    protected secondsBetweenRetries: number;
 
-  constructor({
-    baseUrl,
-    maxRetries = 10,
-    secondsBetweenRetries = 10
-  }: RegistryOptions) {
-    const registryApiUrl = baseUrl;
-    this.baseUri = new URI(baseUrl);
-    this.maxRetries = maxRetries;
-    this.secondsBetweenRetries = secondsBetweenRetries;
+    constructor({
+        baseUrl,
+        maxRetries = 10,
+        secondsBetweenRetries = 10
+    }: RegistryOptions) {
+        const registryApiUrl = baseUrl;
+        this.baseUri = new URI(baseUrl);
+        this.maxRetries = maxRetries;
+        this.secondsBetweenRetries = secondsBetweenRetries;
 
-    this.aspectDefinitionsApi = new AspectDefinitionsApi(registryApiUrl);
-    this.recordsApi = new RecordsApi(registryApiUrl);
-    this.recordsApi.useQuerystring = true; // Use querystring instead of qs to construct URL
-    this.recordAspectsApi = new RecordAspectsApi(registryApiUrl);
-    this.webHooksApi = new WebHooksApi(registryApiUrl);
-  }
+        this.aspectDefinitionsApi = new AspectDefinitionsApi(registryApiUrl);
+        this.recordsApi = new RecordsApi(registryApiUrl);
+        this.recordsApi.useQuerystring = true; // Use querystring instead of qs to construct URL
+        this.recordAspectsApi = new RecordAspectsApi(registryApiUrl);
+        this.webHooksApi = new WebHooksApi(registryApiUrl);
+    }
 
-  getRecordUrl(id: string): string {
-    return this.baseUri.clone().segment("records").segment(id).toString();
-  }
+    getRecordUrl(id: string): string {
+        return this.baseUri
+            .clone()
+            .segment("records")
+            .segment(id)
+            .toString();
+    }
 
-  getAspectDefinitions(): Promise<AspectDefinition[] | Error> {
-    const operation = () => () => this.aspectDefinitionsApi.getAll();
-    return <any>retry(
-      operation(),
-      this.secondsBetweenRetries,
-      this.maxRetries,
-      (e, retriesLeft) =>
-        console.log(
-          formatServiceError(
-            "Failed to GET aspect definitions.",
-            e,
-            retriesLeft
-          )
+    getAspectDefinitions(): Promise<AspectDefinition[] | Error> {
+        const operation = () => () => this.aspectDefinitionsApi.getAll();
+        return <any>retry(
+            operation(),
+            this.secondsBetweenRetries,
+            this.maxRetries,
+            (e, retriesLeft) =>
+                console.log(
+                    formatServiceError(
+                        "Failed to GET aspect definitions.",
+                        e,
+                        retriesLeft
+                    )
+                )
         )
-    )
-      .then(result => result.body)
-      .catch(createServiceError);
-  }
+            .then(result => result.body)
+            .catch(createServiceError);
+    }
 
-  getRecord(
-    id: string,
-    aspect?: Array<string>,
-    optionalAspect?: Array<string>,
-    dereference?: boolean
-  ): Promise<Record | Error> {
-    const operation = (id: string) => () =>
-      this.recordsApi.getById(id, aspect, optionalAspect, dereference);
-    return <any>retry(
-      operation(id),
-      this.secondsBetweenRetries,
-      this.maxRetries,
-      (e, retriesLeft) =>
-        console.log(
-          formatServiceError("Failed to GET records.", e, retriesLeft)
+    getRecord(
+        id: string,
+        aspect?: Array<string>,
+        optionalAspect?: Array<string>,
+        dereference?: boolean
+    ): Promise<Record | Error> {
+        const operation = (id: string) => () =>
+            this.recordsApi.getById(id, aspect, optionalAspect, dereference);
+        return <any>retry(
+            operation(id),
+            this.secondsBetweenRetries,
+            this.maxRetries,
+            (e, retriesLeft) =>
+                console.log(
+                    formatServiceError("Failed to GET records.", e, retriesLeft)
+                )
         )
-    )
-      .then(result => result.body)
-      .catch(createServiceError);
-  }
+            .then(result => result.body)
+            .catch(createServiceError);
+    }
 
-  getRecords<I>(
-    aspect?: Array<string>,
-    optionalAspect?: Array<string>,
-    pageToken?: string,
-    dereference?: boolean,
-    limit?: number
-  ): Promise<RecordsPage<I> | Error> {
-    const operation = (pageToken: string) => () =>
-      this.recordsApi.getAll(
-        aspect,
-        optionalAspect,
-        pageToken,
-        undefined,
-        limit,
-        dereference
-      );
-    return <any>retry(
-      operation(pageToken),
-      this.secondsBetweenRetries,
-      this.maxRetries,
-      (e, retriesLeft) =>
-        console.log(
-          formatServiceError("Failed to GET records.", e, retriesLeft)
+    getRecords<I extends Record>(
+        aspect?: Array<string>,
+        optionalAspect?: Array<string>,
+        pageToken?: string,
+        dereference?: boolean,
+        limit?: number
+    ): Promise<RecordsPage<I> | Error> {
+        const operation = (pageToken: string) => () =>
+            this.recordsApi.getAll(
+                aspect,
+                optionalAspect,
+                pageToken,
+                undefined,
+                limit,
+                dereference
+            );
+        return <any>retry(
+            operation(pageToken),
+            this.secondsBetweenRetries,
+            this.maxRetries,
+            (e, retriesLeft) =>
+                console.log(
+                    formatServiceError("Failed to GET records.", e, retriesLeft)
+                )
         )
-    )
-      .then(result => result.body)
-      .catch(createServiceError);
-  }
+            .then(result => result.body)
+            .catch(createServiceError);
+    }
+
+    getRecordsPageTokens(
+        aspect?: Array<string>,
+        limit?: number
+    ): Promise<string[] | Error> {
+        const operation = () => this.recordsApi.getPageTokens(aspect, limit);
+        return <any>retry(
+            operation,
+            this.secondsBetweenRetries,
+            this.maxRetries,
+            (e, retriesLeft) =>
+                console.log(
+                    formatServiceError(
+                        "Failed to GET records page tokens.",
+                        e,
+                        retriesLeft
+                    )
+                )
+        )
+            .then(result => result.body)
+            .catch(createServiceError);
+    }
 }

--- a/magda-web-client/public/index.html
+++ b/magda-web-client/public/index.html
@@ -7,6 +7,7 @@
     <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700" rel="stylesheet">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+    <link rel="sitemap" type="application/xml" title="Sitemap" href="/sitemap" />
     <script src="/server-config.js"></script>
     <title>Search</title>
   </head>

--- a/magda-web-server/package.json
+++ b/magda-web-server/package.json
@@ -17,7 +17,7 @@
     "@magda/scripts": "^0.0.30-0",
     "@types/chai": "^4.0.1",
     "@types/config": "0.0.32",
-    "@types/express": "^4.0.35",
+    "@types/express": "^4.0.39",
     "@types/lodash": "^4.14.68",
     "@types/mocha": "^2.2.41",
     "@types/nock": "^8.2.1",

--- a/magda-web-server/package.json
+++ b/magda-web-server/package.json
@@ -22,7 +22,9 @@
   },
   "dependencies": {
     "@magda/web-client": "^0.0.30-0",
+    "@magda/typescript-common": "^0.0.30-0",
     "express": "^4.15.3",
+    "sitemap": "^1.13.0",
     "urijs": "^1.18.12",
     "yargs": "^8.0.2"
   },

--- a/magda-web-server/package.json
+++ b/magda-web-server/package.json
@@ -10,15 +10,30 @@
     "start": "node dist/index.js",
     "dev": "run-typescript-in-nodemon src/index.ts",
     "docker-build-local": "create-docker-context-for-node-component --build --push --tag auto --local",
-    "docker-build-prod": "create-docker-context-for-node-component --build --push --tag auto"
+    "docker-build-prod": "create-docker-context-for-node-component --build --push --tag auto",
+    "test": "mocha --compilers ts:@magda/scripts/node_modules/ts-node/register --require @magda/scripts/node_modules/tsconfig-paths/register \"src/test/**/*.spec.ts\""
   },
   "devDependencies": {
     "@magda/scripts": "^0.0.30-0",
+    "@types/chai": "^4.0.1",
     "@types/config": "0.0.32",
     "@types/express": "^4.0.35",
+    "@types/lodash": "^4.14.68",
+    "@types/mocha": "^2.2.41",
+    "@types/nock": "^8.2.1",
+    "@types/sinon": "^2.3.3",
+    "@types/supertest": "^2.0.2",
     "@types/urijs": "^1.15.34",
+    "@types/xml2js": "^0.4.0",
     "@types/yargs": "^6.6.0",
-    "typescript": "~2.5.0"
+    "chai": "^4.1.0",
+    "mocha": "^3.4.2",
+    "nock": "^9.0.14",
+    "sinon": "^2.4.1",
+    "supertest": "^3.0.0",
+    "typed-promisify": "^0.4.0",
+    "typescript": "~2.5.0",
+    "xml2js": "^0.4.19"
   },
   "dependencies": {
     "@magda/web-client": "^0.0.30-0",

--- a/magda-web-server/src/buildSitemapRouter.ts
+++ b/magda-web-server/src/buildSitemapRouter.ts
@@ -4,6 +4,8 @@ const sm = require("sitemap");
 
 // export  express;
 
+const DATASET_REQUIRED_ASPECTS = ["dcat-dataset-strings"];
+
 export default function buildSitemapRouter(
     baseExternalUrl: string,
     baseRegistryUrl: string
@@ -21,14 +23,12 @@ export default function buildSitemapRouter(
 
     app.get("/", (req, res) => {
         registry
-            .getRecordsPageTokens(["dcat-dataset-strings"])
+            .getRecordsPageTokens(DATASET_REQUIRED_ASPECTS)
             .then(handleError)
             .then(async result => {
                 const datasetsPages = result.map(token => {
                     return (
-                        baseExternalUrl +
-                        "/sitemap/dataset/afterToken/" +
-                        token
+                        baseExternalUrl + "/sitemap/dataset/afterToken/" + token
                     );
                 });
 
@@ -55,7 +55,7 @@ export default function buildSitemapRouter(
             cacheTime: 600000, // 600 sec - cache purge period
             urls: [
                 {
-                    url: `/`,
+                    url: ``,
                     changefreq: "weekly"
                 }
             ]
@@ -74,7 +74,7 @@ export default function buildSitemapRouter(
         const afterToken: string = req.params.afterToken;
 
         registry
-            .getRecords(["dcat-dataset-strings"], null, afterToken, false)
+            .getRecords(DATASET_REQUIRED_ASPECTS, null, afterToken, false)
             .then(handleError)
             .then(records => {
                 const sitemap = sm.createSitemap({

--- a/magda-web-server/src/buildSitemapRouter.ts
+++ b/magda-web-server/src/buildSitemapRouter.ts
@@ -1,0 +1,75 @@
+import * as express from "express";
+import Registry from "@magda/typescript-common/dist/registry/RegistryClient";
+const sm = require("sitemap");
+
+// export  express;
+
+export default function buildSitemapRouter(
+    baseExternalUrl: string,
+    baseRegistryUrl: string
+): express.Router {
+    console.log(baseRegistryUrl);
+    const app = express();
+    const registry = new Registry({ baseUrl: baseRegistryUrl });
+
+    type CrawlPage = {
+        afterToken: string;
+    };
+
+    async function doFullCrawl(afterToken?: string): Promise<CrawlPage[]> {
+        const pageResult = await registry.getRecords(
+            ["dcat-dataset-strings"],
+            [],
+            afterToken,
+            false,
+            1000
+        );
+
+        if (pageResult instanceof Error) {
+            throw pageResult;
+        }
+
+        console.log("Crawling after " + pageResult.nextPageToken);
+        const theRest = pageResult.nextPageToken
+            ? await doFullCrawl(pageResult.nextPageToken)
+            : [];
+
+        return [{ afterToken }].concat(theRest);
+    }
+
+    app.get("/index.xml", (req, res) => {
+        doFullCrawl()
+            .then(result => {
+                const datasetsPages = result.map(page => {
+                    return (
+                        baseExternalUrl +
+                        "/datasets/afterToken/" +
+                        page.afterToken
+                    );
+                });
+
+                const smi = sm.createSitemapIndex({
+                    urls: [baseExternalUrl + "/standard.xml"].concat(
+                        datasetsPages
+                    )
+                });
+
+                smi.toXML((err: Error, xml: string) => {
+                    if (err) {
+                        res.status(500).end();
+                    }
+
+                    res.header("Content-Type", "application/xml");
+                    res.send(xml);
+                });
+            })
+            .catch(e => {
+                console.error(e);
+                res.status(500).end();
+            });
+    });
+
+    app.get("datasets/afterToken/:afterToken");
+
+    return app;
+}

--- a/magda-web-server/src/index.ts
+++ b/magda-web-server/src/index.ts
@@ -24,12 +24,14 @@ const argv = yargs
         describe:
             "The absolute base URL of the Magda site, when accessed externally. Used for building sitemap URLs which must be absolute.",
         type: "string",
+        default: "http://localhost:6100/",
         required: true
     })
     .option("registryApiBaseUrlInternal", {
         describe: "The url of the registry api for use within the cluster",
         type: "string",
-        default: "http://registry-api/"
+        default: "http://localhost:6101/",
+        required: true
     })
     .option("baseUrl", {
         describe:

--- a/magda-web-server/src/index.ts
+++ b/magda-web-server/src/index.ts
@@ -2,6 +2,9 @@ import * as express from "express";
 import * as path from "path";
 import * as URI from "urijs";
 import * as yargs from "yargs";
+
+import Registry from "@magda/typescript-common/dist/registry/RegistryClient";
+
 import buildSitemapRouter from "./buildSitemapRouter";
 
 const argv = yargs
@@ -159,7 +162,10 @@ topLevelRoutes.forEach(topLevelRoute => {
 
 app.use(
     "/sitemap",
-    buildSitemapRouter(argv.baseExternalUrl, argv.registryApiBaseUrlInternal)
+    buildSitemapRouter({
+        baseExternalUrl: argv.baseExternalUrl,
+        registry: new Registry({ baseUrl: argv.registryApiBaseUrlInternal })
+    })
 );
 
 app.listen(argv.listenPort);

--- a/magda-web-server/src/index.ts
+++ b/magda-web-server/src/index.ts
@@ -30,7 +30,7 @@ const argv = yargs
     .option("registryApiBaseUrlInternal", {
         describe: "The url of the registry api for use within the cluster",
         type: "string",
-        default: "http://localhost:6101/",
+        default: "http://localhost:6101/v0",
         required: true
     })
     .option("baseUrl", {

--- a/magda-web-server/src/index.ts
+++ b/magda-web-server/src/index.ts
@@ -17,8 +17,20 @@ const argv = yargs
         type: "boolean",
         default: false
     })
+    .option("baseExternalUrl", {
+        describe:
+            "The absolute base URL of the Magda site, when accessed externally. Used for building sitemap URLs which must be absolute.",
+        type: "string",
+        required: true
+    })
+    .option("registryApiBaseUrlInternal", {
+        describe: "The url of the registry api for use within the cluster",
+        type: "string",
+        default: "http://registry-api/"
+    })
     .option("baseUrl", {
-        describe: "The base URL of the MAGDA Gateway.",
+        describe:
+            "The base URL of the MAGDA Gateway, for building the base URLs of the APIs when not manually specified. Can be relative.",
         type: "string",
         default: "/"
     })
@@ -147,7 +159,7 @@ topLevelRoutes.forEach(topLevelRoute => {
 
 app.use(
     "/sitemap",
-    buildSitemapRouter("http://example.com", argv.registryApiBaseUrl)
+    buildSitemapRouter(argv.baseExternalUrl, argv.registryApiBaseUrlInternal)
 );
 
 app.listen(argv.listenPort);

--- a/magda-web-server/src/index.ts
+++ b/magda-web-server/src/index.ts
@@ -2,6 +2,7 @@ import * as express from "express";
 import * as path from "path";
 import * as URI from "urijs";
 import * as yargs from "yargs";
+import buildSitemapRouter from "./buildSitemapRouter";
 
 const argv = yargs
     .config()
@@ -143,6 +144,11 @@ topLevelRoutes.forEach(topLevelRoute => {
         res.sendFile(path.join(clientBuild, "index.html"));
     });
 });
+
+app.use(
+    "/sitemap",
+    buildSitemapRouter("http://example.com", argv.registryApiBaseUrl)
+);
 
 app.listen(argv.listenPort);
 console.log("Listening on port " + argv.listenPort);

--- a/magda-web-server/src/test/sitemap.spec.ts
+++ b/magda-web-server/src/test/sitemap.spec.ts
@@ -1,0 +1,102 @@
+import {} from "mocha";
+// import * as sinon from "sinon";
+// import * as express from "express";
+import { expect } from "chai";
+import * as nock from "nock";
+import * as request from "supertest";
+import { parseString } from "xml2js";
+import buildSitemapRouter from "../buildSitemapRouter";
+import { promisify } from "typed-promisify";
+
+const noOptionsParseString = (
+    string: string,
+    callback: (err: any, result: any) => void
+) => parseString(string, callback);
+const parsePromise = promisify(noOptionsParseString);
+
+describe("sitemap router", () => {
+    const externalUrl = "http://example.com";
+    const registryUrl = "http://registry.example.com";
+
+    describe("/", () => {
+        it("should reflect page tokens from registry", () => {
+            const router = buildSitemapRouter(externalUrl, registryUrl);
+            const registryScope = nock(registryUrl);
+            const tokens = [0, 100, 200];
+
+            registryScope
+                .get("/records/pagetokens?aspect=dcat-dataset-strings")
+                .reply(200, tokens);
+
+            return request(router)
+                .get("/")
+                .expect(200)
+                .then(res => parsePromise(res.text))
+                .then(xmlObj => {
+                    const urls = xmlObj.sitemapindex.sitemap.map(
+                        (mapEntry: any) => mapEntry.loc[0]
+                    );
+
+                    const expected = tokens.map(
+                        token =>
+                            externalUrl + "/sitemap/dataset/afterToken/" + token
+                    );
+
+                    expect(urls).to.eql(
+                        [externalUrl + "/sitemap/main"].concat(expected)
+                    );
+                });
+        });
+    });
+
+    describe("/main", () => {
+        it("should return the home page", () => {
+            const router = buildSitemapRouter(externalUrl, registryUrl);
+
+            return request(router)
+                .get("/main")
+                .expect(200)
+                .then(res => parsePromise(res.text))
+                .then(xmlObj => {
+                    expect(xmlObj.urlset.url[0].loc[0]).to.equal(
+                        externalUrl + "/"
+                    );
+                });
+        });
+    });
+
+    describe("/dataset/afterToken/:afterToken", () => {
+        it("should return the datasets pages for the corresponding datasets page with that token", () => {
+            const token = "1234";
+            const router = buildSitemapRouter(externalUrl, registryUrl);
+            const registryScope = nock(registryUrl);
+            const recordIds = ["a", "b", "c"];
+
+            registryScope
+                .get(
+                    `/records?aspect=dcat-dataset-strings&optionalAspect=&pageToken=${token}&dereference=false`
+                )
+                .reply(200, {
+                    records: recordIds.map(id => ({
+                        id
+                    }))
+                });
+
+            return request(router)
+                .get(`/dataset/afterToken/${token}`)
+                .expect(200)
+                .then(res => parsePromise(res.text))
+                .then(xmlObj => {
+                    const urls = xmlObj.urlset.url.map(
+                        (url: any) => url.loc[0]
+                    );
+
+                    const expectedUrls = recordIds.map(
+                        id => `${externalUrl}/dataset/${encodeURIComponent(id)}`
+                    );
+
+                    expect(urls).to.eql(expectedUrls);
+                });
+        });
+    });
+});

--- a/magda-web-server/src/test/sitemap.spec.ts
+++ b/magda-web-server/src/test/sitemap.spec.ts
@@ -1,12 +1,13 @@
 import {} from "mocha";
-// import * as sinon from "sinon";
-// import * as express from "express";
+import * as sinon from "sinon";
+import * as express from "express";
 import { expect } from "chai";
 import * as nock from "nock";
-import * as request from "supertest";
+import * as supertest from "supertest";
 import { parseString } from "xml2js";
 import buildSitemapRouter from "../buildSitemapRouter";
 import { promisify } from "typed-promisify";
+import Registry from "@magda/typescript-common/dist/registry/RegistryClient";
 
 const noOptionsParseString = (
     string: string,
@@ -15,22 +16,39 @@ const noOptionsParseString = (
 const parsePromise = promisify(noOptionsParseString);
 
 describe("sitemap router", () => {
-    const externalUrl = "http://example.com";
+    const baseExternalUrl = "http://example.com";
     const registryUrl = "http://registry.example.com";
+    const registry = new Registry({
+        baseUrl: registryUrl,
+        maxRetries: 0
+    });
+
+    let router: express.Router;
+    let registryScope: nock.Scope;
+
+    beforeEach(() => {
+        router = buildSitemapRouter({ baseExternalUrl, registry });
+        registryScope = nock(registryUrl);
+    });
+
+    afterEach(() => {
+        if ((<sinon.SinonStub>console.error).restore) {
+            (<sinon.SinonStub>console.error).restore();
+        }
+    });
 
     describe("/", () => {
         it("should reflect page tokens from registry", () => {
-            const router = buildSitemapRouter(externalUrl, registryUrl);
-            const registryScope = nock(registryUrl);
             const tokens = [0, 100, 200];
 
             registryScope
                 .get("/records/pagetokens?aspect=dcat-dataset-strings")
                 .reply(200, tokens);
 
-            return request(router)
+            return supertest(router)
                 .get("/")
                 .expect(200)
+                .expect(checkRequestMetadata)
                 .then(res => parsePromise(res.text))
                 .then(xmlObj => {
                     const urls = xmlObj.sitemapindex.sitemap.map(
@@ -39,37 +57,49 @@ describe("sitemap router", () => {
 
                     const expected = tokens.map(
                         token =>
-                            externalUrl + "/sitemap/dataset/afterToken/" + token
+                            baseExternalUrl +
+                            "/sitemap/dataset/afterToken/" +
+                            token
                     );
 
                     expect(urls).to.eql(
-                        [externalUrl + "/sitemap/main"].concat(expected)
+                        [baseExternalUrl + "/sitemap/main"].concat(expected)
                     );
                 });
+        });
+
+        it("should handle registry failure as 500", () => {
+            silenceConsoleError();
+
+            registryScope
+                .get("/records/pagetokens?aspect=dcat-dataset-strings")
+                .reply(500);
+
+            return supertest(router)
+                .get("/")
+                .expect(500);
         });
     });
 
     describe("/main", () => {
         it("should return the home page", () => {
-            const router = buildSitemapRouter(externalUrl, registryUrl);
-
-            return request(router)
+            return supertest(router)
                 .get("/main")
                 .expect(200)
+                .expect(checkRequestMetadata)
                 .then(res => parsePromise(res.text))
                 .then(xmlObj => {
                     expect(xmlObj.urlset.url[0].loc[0]).to.equal(
-                        externalUrl + "/"
+                        baseExternalUrl + "/"
                     );
                 });
         });
     });
 
     describe("/dataset/afterToken/:afterToken", () => {
+        const token = "1234";
+
         it("should return the datasets pages for the corresponding datasets page with that token", () => {
-            const token = "1234";
-            const router = buildSitemapRouter(externalUrl, registryUrl);
-            const registryScope = nock(registryUrl);
             const recordIds = ["a", "b", "c"];
 
             registryScope
@@ -82,9 +112,10 @@ describe("sitemap router", () => {
                     }))
                 });
 
-            return request(router)
+            return supertest(router)
                 .get(`/dataset/afterToken/${token}`)
                 .expect(200)
+                .expect(checkRequestMetadata)
                 .then(res => parsePromise(res.text))
                 .then(xmlObj => {
                     const urls = xmlObj.urlset.url.map(
@@ -92,11 +123,40 @@ describe("sitemap router", () => {
                     );
 
                     const expectedUrls = recordIds.map(
-                        id => `${externalUrl}/dataset/${encodeURIComponent(id)}`
+                        id =>
+                            `${baseExternalUrl}/dataset/${encodeURIComponent(
+                                id
+                            )}`
                     );
 
                     expect(urls).to.eql(expectedUrls);
                 });
         });
+
+        it("should handle registry failure as 500", () => {
+            silenceConsoleError();
+
+            registryScope
+                .get(
+                    "/records?aspect=dcat-dataset-strings&optionalAspect=&pageToken=${token}&dereference=false"
+                )
+                .reply(500);
+
+            return supertest(router)
+                .get(`/dataset/afterToken/${token}`)
+                .expect(500);
+        });
     });
+
+    function silenceConsoleError() {
+        sinon.stub(console, "error");
+    }
+
+    /**
+     * Make sure that encoding is UTF-8 and content-type is application/xml.
+     */
+    function checkRequestMetadata(res: supertest.Response) {
+        expect(res.charset).to.equal("utf-8");
+        expect(res.header["content-type"]).to.contain("application/xml");
+    }
 });

--- a/magda-web-server/tsconfig.json
+++ b/magda-web-server/tsconfig.json
@@ -5,6 +5,9 @@
         "paths": {
             "@magda/web-client/dist/*": [
                 "./node_modules/@magda/web-client/src/*"
+            ],
+            "@magda/typescript-common/dist/*": [
+              "./node_modules/@magda/typescript-common/src/*"
             ]
         }
     }


### PR DESCRIPTION
- index.html now links to `/sitemap`
- `/sitemap` generates a sitemap index which links to a standard sitemap that just has the index, and also links to sitemaps for every 100 datasets by linking to urls that have the pageToken as a parameter
- To get these page tokens, the web pod calls a new endpoint in the registry at `/records/pagetokens`, which queries the database to get tokens for each page given a certain `limit`.
- Each datasets sitemap gives the url of 100 datasets after the provided pagetoken.

Fixes #179 