### PR TITLE
Update lerna version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "devDependencies": {
     "@types/lodash": "^4.14.74",
-    "lerna": "^2.0.0-rc.5"
+    "lerna": "^2.4.0"
   },
   "scripts": {
     "build": "lerna run build --stream --concurrency=1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "devDependencies": {
     "@types/lodash": "^4.14.74",
-    "lerna": "^2.4.0"
+    "lerna": "^2.5.1"
   },
   "scripts": {
     "build": "lerna run build --stream --concurrency=1",


### PR DESCRIPTION
Update lerna version in package.json to match version in lerna.json.
Currently `npm run build` fails due to incompatible lerna version. Changing the version here should fix that problem.