### PR TITLE
Tweak memory limits for search-api and registry-api.

### DIFF
--- a/deploy/helm/magda-dev.yml
+++ b/deploy/helm/magda-dev.yml
@@ -65,7 +65,7 @@ registry-api:
       memory: 0
     limits:
       cpu: 200m
-      memory: 250Mi
+      memory: 1000Mi
 search-api:
   resources:
     requests:
@@ -73,7 +73,7 @@ search-api:
       memory: 0
     limits:
       cpu: 200m
-      memory: 250Mi
+      memory: 1000Mi
 web-server:
   resources:
     requests:

--- a/deploy/helm/magda/charts/registry-api/templates/deployment.yaml
+++ b/deploy/helm/magda/charts/registry-api/templates/deployment.yaml
@@ -43,3 +43,5 @@ spec:
         ]
         ports:
         - containerPort: 80
+        resources:
+{{ toYaml .Values.resources | indent 10 }}


### PR DESCRIPTION
Also make the registry-api limits actually apply.

The search API was being repeatedly killed on magda-dev because it exceeded the memory limit.  The registry-api would have, too, except that the limit was missing from the deployment spec.