### PR TITLE
Namespaced IDs

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -44,7 +44,8 @@
             ],
             "args":[
                 "--config", "${workspaceRoot}/deploy/connector-config/australian-bureau-of-meteorology.json",
-                "--interactive"
+                "--userId", "00000000-0000-4000-8000-000000000000",
+                "--jwtSecret", "squirrel"
             ],
             "cwd": "${workspaceRoot}/magda-csw-connector"
         },

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,4 @@
 ## 0.0.32
 
 * Connectors now create organizations, datasets, and distributions with IDs prefixed by the type of record and by the ID of the connector. For example, `org-bom-Australian Bureau of Meteorology` is the organization with the ID `Australian Bureau of Meteorology` from the connector with ID `bom`. Other type prefixes are `ds` for dataset and `dist` for distributions. This change avoids conflicting IDs from different sources.
+* Fixed a race condition in the registry that could lead to an error when multiple requests tried to create/update the same record simultaneously, which is fairly common when creating organizations in the CSW connector.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
 ## 0.0.32
 
-* Connectors now create organizations, datasets, and distributions with IDs prefixed by the type of record and by the ID of the connector. For example, `org-bom-Australian Bureau of Meteorology` is the organization with the ID `Australian Bureau of Meteorology` from the connector with ID `bom`. Other type prefixes are `ds` for dataset and `dist` for distributions. This change avoids conflicting IDs from different sources.
+* Connectors now create organizations, datasets, and distributions with IDs prefixed by the type of record and by the ID of the connector. For example, `org-bom-Australian Bureau of Meteorology` is the organization with the ID `Australian Bureau of Meteorology` from the connector with ID `bom`. Other type prefixes are `ds` for dataset and `dist` for distribution. This change avoids conflicting IDs from different sources.
 * Fixed a race condition in the registry that could lead to an error when multiple requests tried to create/update the same record simultaneously, which is fairly common when creating organizations in the CSW connector.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,3 @@
+## 0.0.32
+
+* Connectors now create organizations, datasets, and distributions with IDs prefixed by the type of record and by the ID of the connector. For example, `org-bom-Australian Bureau of Meteorology` is the organization with the ID `Australian Bureau of Meteorology` from the connector with ID `bom`. Other type prefixes are `ds` for dataset and `dist` for distributions. This change avoids conflicting IDs from different sources.

--- a/deploy/connector-config/act-government.json
+++ b/deploy/connector-config/act-government.json
@@ -1,5 +1,6 @@
 {
     "type": "magda-project-open-data-connector",
+    "id": "act",
     "name": "ACT Government data.act.gov.au",
     "sourceUrl": "http://www.data.act.gov.au/data.json",
     "schedule": "0 0 */3 * *"

--- a/deploy/connector-config/australian-bureau-of-meteorology.json
+++ b/deploy/connector-config/australian-bureau-of-meteorology.json
@@ -1,5 +1,6 @@
 {
     "type": "magda-csw-connector",
+    "id": "bom",
     "name": "Australian Bureau of Meteorology",
     "sourceUrl": "http://www.bom.gov.au/geonetwork/srv/eng/csw",
     "pageSize": 100,

--- a/deploy/connector-config/australian-institute-of-marine-science.json
+++ b/deploy/connector-config/australian-institute-of-marine-science.json
@@ -1,5 +1,6 @@
 {
     "type": "magda-csw-connector",
+    "id": "aims",
     "name": "Australian Institute of Marine Science",
     "sourceUrl": "http://data.aims.gov.au/geonetwork/srv/eng/csw",
     "pageSize": 100,

--- a/deploy/connector-config/australian-oceans-data-network.json
+++ b/deploy/connector-config/australian-oceans-data-network.json
@@ -1,5 +1,6 @@
 {
     "type": "magda-csw-connector",
+    "id": "aodn",
     "name": "Australian Oceans Data Network",
     "sourceUrl": "http://catalogue.aodn.org.au/geonetwork/srv/eng/csw",
     "pageSize": 100,

--- a/deploy/connector-config/brisbane-city-council.json
+++ b/deploy/connector-config/brisbane-city-council.json
@@ -1,5 +1,6 @@
 {
     "type": "magda-ckan-connector",
+    "id": "brisbane",
     "name": "Brisbane City Council",
     "sourceUrl": "https://www.data.brisbane.qld.gov.au/data/",
     "pageSize": 100,

--- a/deploy/connector-config/city-of-hobart-open-data-portal.json
+++ b/deploy/connector-config/city-of-hobart-open-data-portal.json
@@ -1,5 +1,6 @@
 {
     "type": "magda-project-open-data-connector",
+    "id": "hobart",
     "name": "City of Hobart Open Data Portal",
     "sourceUrl": "http://data-1-hobartcc.opendata.arcgis.com/data.json",
     "schedule": "30 2 */3 * *"

--- a/deploy/connector-config/city-of-launceston-open-data.json
+++ b/deploy/connector-config/city-of-launceston-open-data.json
@@ -1,5 +1,6 @@
 {
     "type": "magda-project-open-data-connector",
+    "id": "launceston",
     "name": "City of Launceston Open Data",
     "sourceUrl": "http://opendata.launceston.tas.gov.au/data.json",
     "schedule": "0 3 */3 * *"

--- a/deploy/connector-config/csiro-marlin.json
+++ b/deploy/connector-config/csiro-marlin.json
@@ -1,5 +1,6 @@
 {
     "type": "magda-csw-connector",
+    "id": "marlin",
     "name": "CSIRO Marlin",
     "sourceUrl": "http://www.marlin.csiro.au/geonetwork/srv/eng/csw",
     "pageSize": 50,

--- a/deploy/connector-config/data-gov-au.json
+++ b/deploy/connector-config/data-gov-au.json
@@ -1,5 +1,6 @@
 {
     "type": "magda-ckan-connector",
+    "id": "dga",
     "name": "data.gov.au",
     "sourceUrl": "https://data.gov.au/",
     "pageSize": 1000,

--- a/deploy/connector-config/esta-open-data.json
+++ b/deploy/connector-config/esta-open-data.json
@@ -1,5 +1,6 @@
 {
     "type": "magda-project-open-data-connector",
+    "id": "esta",
     "name": "ESTA Open Data",
     "sourceUrl": "http://data-esta000.opendata.arcgis.com/data.json",
     "schedule": "30 4 */3 * *"

--- a/deploy/connector-config/geoscience-australia.json
+++ b/deploy/connector-config/geoscience-australia.json
@@ -1,5 +1,6 @@
 {
     "type": "magda-csw-connector",
+    "id": "ga",
     "name": "Geoscience Australia",
     "sourceUrl": "http://www.ga.gov.au/geonetwork/srv/en/csw",
     "pageSize": 100,

--- a/deploy/connector-config/logan-city-council.json
+++ b/deploy/connector-config/logan-city-council.json
@@ -1,5 +1,6 @@
 {
     "type": "magda-project-open-data-connector",
+    "id": "logan",
     "name": "Logan City Council",
     "sourceUrl": "http://data-logancity.opendata.arcgis.com/data.json",
     "schedule": "30 5 */3 * *"

--- a/deploy/connector-config/melbourne-data.json
+++ b/deploy/connector-config/melbourne-data.json
@@ -1,5 +1,6 @@
 {
     "type": "magda-project-open-data-connector",
+    "id": "melbourne",
     "name": "Melbourne Data",
     "sourceUrl": "https://data.melbourne.vic.gov.au/data.json",
     "schedule": "0 6 */3 * *"

--- a/deploy/connector-config/mineral-resources-tasmania.json
+++ b/deploy/connector-config/mineral-resources-tasmania.json
@@ -1,5 +1,6 @@
 {
     "type": "magda-csw-connector",
+    "id": "mrt",
     "name": "Mineral Resources Tasmania",
     "sourceUrl": "http://www.mrt.tas.gov.au/web-catalogue/srv/eng/csw",
     "pageSize": 100,

--- a/deploy/connector-config/moreton-bay-regional-council-data-portal.json
+++ b/deploy/connector-config/moreton-bay-regional-council-data-portal.json
@@ -1,5 +1,6 @@
 {
     "type": "magda-project-open-data-connector",
+    "id": "moretonbay",
     "name": "Moreton Bay Regional Council Data Portal",
     "sourceUrl": "http://data.moretonbay.qld.gov.au/data.json",
     "schedule": "0 7 */3 * *"

--- a/deploy/connector-config/national-environmental-information-infrastructure.json
+++ b/deploy/connector-config/national-environmental-information-infrastructure.json
@@ -1,5 +1,6 @@
 {
     "type": "magda-csw-connector",
+    "id": "neii",
     "name": "National Environmental Information Infrastructure",
     "sourceUrl": "http://neii.bom.gov.au/services/catalogue/csw",
     "pageSize": 100,

--- a/deploy/connector-config/navy-meteorology-and-oceanography.json
+++ b/deploy/connector-config/navy-meteorology-and-oceanography.json
@@ -1,5 +1,6 @@
 {
     "type": "magda-csw-connector",
+    "id": "metoc",
     "name": "Navy Meteorology and Oceanography (METOC) ",
     "sourceUrl": "http://www.metoc.gov.au/geonetwork/srv/en/csw",
     "pageSize": 100,

--- a/deploy/connector-config/new-south-wales.json
+++ b/deploy/connector-config/new-south-wales.json
@@ -1,5 +1,6 @@
 {
     "type": "magda-ckan-connector",
+    "id": "nsw",
     "name": "New South Wales Government",
     "sourceUrl": "https://data.nsw.gov.au/data/",
     "pageSize": 100,

--- a/deploy/connector-config/nsw-land-and-property.json
+++ b/deploy/connector-config/nsw-land-and-property.json
@@ -1,5 +1,6 @@
 {
     "type": "magda-csw-connector",
+    "id": "sdinsw",
     "name": "NSW Land and Property",
     "sourceUrl": "https://sdi.nsw.gov.au/csw",
     "pageSize": 100,

--- a/deploy/connector-config/queensland-government.json
+++ b/deploy/connector-config/queensland-government.json
@@ -1,5 +1,6 @@
 {
     "type": "magda-ckan-connector",
+    "id": "qld",
     "name": "Queensland Government",
     "sourceUrl": "https://data.qld.gov.au/",
     "pageSize": 100,

--- a/deploy/connector-config/south-australia-government.json
+++ b/deploy/connector-config/south-australia-government.json
@@ -1,5 +1,6 @@
 {
     "type": "magda-ckan-connector",
+    "id": "sa",
     "name": "South Australia Government",
     "sourceUrl": "https://data.sa.gov.au/data/",
     "pageSize": 100,

--- a/deploy/connector-config/tasmania-thelist.json
+++ b/deploy/connector-config/tasmania-thelist.json
@@ -1,5 +1,6 @@
 {
     "type": "magda-csw-connector",
+    "id": "listtas",
     "name": "Tasmania TheList",
     "sourceUrl": "https://data.thelist.tas.gov.au:443/datagn/srv/eng/csw",
     "pageSize": 100,

--- a/deploy/connector-config/terrestrial-ecosystem-research-network.json
+++ b/deploy/connector-config/terrestrial-ecosystem-research-network.json
@@ -1,5 +1,6 @@
 {
     "type": "magda-csw-connector",
+    "id": "tern",
     "name": "Terrestrial Ecosystem Research Network",
     "sourceUrl": "http://data.auscover.org.au/geonetwork/srv/eng/csw",
     "pageSize": 100,

--- a/deploy/connector-config/victoria-government.json
+++ b/deploy/connector-config/victoria-government.json
@@ -1,5 +1,6 @@
 {
     "type": "magda-ckan-connector",
+    "id": "vic",
     "name": "Victoria Government",
     "sourceUrl": "https://www.data.vic.gov.au/data/",
     "pageSize": 100,

--- a/deploy/connector-config/western-australia-government.json
+++ b/deploy/connector-config/western-australia-government.json
@@ -1,5 +1,6 @@
 {
     "type": "magda-ckan-connector",
+    "id": "wa",
     "name": "Western Australia Government",
     "sourceUrl": "http://catalogue.beta.data.wa.gov.au/",
     "pageSize": 100,

--- a/magda-ckan-connector/aspect-templates/dataset-source.js
+++ b/magda-ckan-connector/aspect-templates/dataset-source.js
@@ -3,5 +3,6 @@ var ckan = libraries.ckan;
 return {
     type: 'ckan-dataset',
     url: ckan.getPackageShowUrl(dataset.id),
+    id: ckan.id,
     name: ckan.name
 };

--- a/magda-ckan-connector/aspect-templates/distribution-source.js
+++ b/magda-ckan-connector/aspect-templates/distribution-source.js
@@ -2,5 +2,7 @@ var ckan = libraries.ckan;
 
 return {
     type: 'ckan-resource',
-    url: ckan.getResourceShowUrl(distribution.id)
+    url: ckan.getResourceShowUrl(distribution.id),
+    id: ckan.id,
+    name: ckan.name
 };

--- a/magda-ckan-connector/aspect-templates/organization-source.js
+++ b/magda-ckan-connector/aspect-templates/organization-source.js
@@ -2,5 +2,7 @@ var ckan = libraries.ckan;
 
 return {
     type: 'ckan-organization',
-    url: ckan.getOrganizationShowUrl(organization.id)
+    url: ckan.getOrganizationShowUrl(organization.id),
+    id: ckan.id,
+    name: ckan.name
 };

--- a/magda-ckan-connector/src/Ckan.ts
+++ b/magda-ckan-connector/src/Ckan.ts
@@ -40,6 +40,7 @@ export interface CkanOrganizationListResponse {
 
 export interface CkanOptions {
     baseUrl: string;
+    id: string,
     name: string;
     apiBaseUrl?: string;
     pageSize?: number;
@@ -49,6 +50,7 @@ export interface CkanOptions {
 }
 
 export default class Ckan implements ConnectorSource {
+    public readonly id: string;
     public readonly name: string;
     public readonly pageSize: number;
     public readonly maxRetries: number;
@@ -58,6 +60,7 @@ export default class Ckan implements ConnectorSource {
 
     constructor({
         baseUrl,
+        id,
         name,
         apiBaseUrl,
         pageSize = 1000,
@@ -65,12 +68,14 @@ export default class Ckan implements ConnectorSource {
         secondsBetweenRetries = 10,
         ignoreHarvestSources = []
     }: CkanOptions) {
+        this.id = id;
         this.name = name;
         this.pageSize = pageSize;
         this.maxRetries = maxRetries;
         this.secondsBetweenRetries = secondsBetweenRetries;
         this.ignoreHarvestSources = ignoreHarvestSources;
         this.urlBuilder = new CkanUrlBuilder({
+            id: id,
             name: name,
             baseUrl,
             apiBaseUrl

--- a/magda-ckan-connector/src/CkanTransformer.ts
+++ b/magda-ckan-connector/src/CkanTransformer.ts
@@ -1,3 +1,4 @@
+import ConnectorRecordId from "@magda/typescript-common/dist/ConnectorRecordId";
 import JsonTransformer, { JsonTransformerOptions } from '@magda/typescript-common/dist/JsonTransformer';
 
 export default class CkanTransformer extends JsonTransformer {
@@ -5,16 +6,16 @@ export default class CkanTransformer extends JsonTransformer {
         super(options);
     }
 
-    getIdFromJsonOrganization(jsonOrganization: any): string {
-        return jsonOrganization.id;
+    getIdFromJsonOrganization(jsonOrganization: any, sourceId: string): ConnectorRecordId {
+        return new ConnectorRecordId(jsonOrganization.id, "Organization", sourceId);
     }
 
-    getIdFromJsonDataset(jsonDataset: any): string {
-        return jsonDataset.id;
+    getIdFromJsonDataset(jsonDataset: any, sourceId: string): ConnectorRecordId {
+        return new ConnectorRecordId(jsonDataset.id, "Dataset", sourceId);
     }
 
-    getIdFromJsonDistribution(jsonDistribution: any, jsonDataset: any): string {
-        return jsonDistribution.id;
+    getIdFromJsonDistribution(jsonDistribution: any, jsonDataset: any, sourceId: string): ConnectorRecordId {
+        return new ConnectorRecordId(jsonDistribution.id, "Distribution", sourceId);
     }
 
     getNameFromJsonOrganization(jsonOrganization: any): string {

--- a/magda-ckan-connector/src/CkanUrlBuilder.ts
+++ b/magda-ckan-connector/src/CkanUrlBuilder.ts
@@ -1,18 +1,21 @@
 import * as URI from 'urijs';
 
 export interface CkanUrlBuilderOptions {
+    id: string,
     name?: string,
     baseUrl: string;
     apiBaseUrl?: string;
 }
 
 export default class CkanUrlBuilder {
+    public readonly id: string;
     public readonly name: string;
     public readonly baseUrl: uri.URI;
     public readonly apiBaseUrl: uri.URI;
 
     constructor(options: CkanUrlBuilderOptions) {
-        this.name = options.name || 'CKAN';
+        this.id = options.id;
+        this.name = options.name || options.id;
         this.baseUrl = new URI(options.baseUrl);
 
         if (options.apiBaseUrl) {

--- a/magda-ckan-connector/src/createTransformer.ts
+++ b/magda-ckan-connector/src/createTransformer.ts
@@ -6,6 +6,7 @@ import * as URI from 'urijs';
 
 export interface CreateTransformerOptions {
     name: string,
+    id: string,
     sourceUrl: string,
     datasetAspectBuilders: AspectBuilder[],
     distributionAspectBuilders: AspectBuilder[],
@@ -14,12 +15,14 @@ export interface CreateTransformerOptions {
 
 export default function createTransformer({
     name,
+    id,
     sourceUrl,
     datasetAspectBuilders,
     distributionAspectBuilders,
     organizationAspectBuilders
 }: CreateTransformerOptions) {
     return new CkanTransformer({
+        sourceId: id,
         datasetAspectBuilders: datasetAspectBuilders,
         distributionAspectBuilders: distributionAspectBuilders,
         organizationAspectBuilders: organizationAspectBuilders,
@@ -27,6 +30,7 @@ export default function createTransformer({
             moment: moment,
             URI: URI,
             ckan: new CkanUrlBuilder({
+                id: id,
                 name: name,
                 baseUrl: sourceUrl
             })

--- a/magda-ckan-connector/src/index.ts
+++ b/magda-ckan-connector/src/index.ts
@@ -11,6 +11,12 @@ const argv = addJwtSecretFromEnvVar(
     yargs
         .config()
         .help()
+        .option("id", {
+            describe:
+                "The ID of this connector. Datasets created by this connector will have an ID prefixed with this ID.",
+            type: "string",
+            demandOption: true
+        })
         .option("name", {
             describe:
                 "The name of this connector, to be displayed to users to indicate the source of datasets.",
@@ -183,6 +189,7 @@ const organizationAspectBuilders: AspectBuilder[] = [
 
 const ckan = new Ckan({
     baseUrl: argv.sourceUrl,
+    id: argv.id,
     name: argv.name,
     pageSize: argv.pageSize,
     ignoreHarvestSources: argv.ignoreHarvestSources,
@@ -195,6 +202,7 @@ const registry = new Registry({
 });
 
 const transformerOptions = {
+    id: argv.id,
     name: argv.name,
     sourceUrl: argv.sourceUrl,
     pageSize: argv.pageSize,

--- a/magda-csw-connector/aspect-templates/dataset-source.js
+++ b/magda-csw-connector/aspect-templates/dataset-source.js
@@ -6,5 +6,6 @@ const identifier = jsonpath.value(dataset.json, '$.fileIdentifier[*].CharacterSt
 return {
     type: 'csw-dataset',
     url: csw.getRecordByIdUrl(identifier),
+    id: csw.id,
     name: csw.name
 };

--- a/magda-csw-connector/aspect-templates/distribution-source.js
+++ b/magda-csw-connector/aspect-templates/distribution-source.js
@@ -6,5 +6,6 @@ const identifier = jsonpath.value(dataset.json, '$.fileIdentifier[*].CharacterSt
 return {
     type: 'csw-distribution',
     url: csw.getRecordByIdUrl(identifier),
+    id: csw.id,
     name: csw.name
 };

--- a/magda-csw-connector/aspect-templates/organization-source.js
+++ b/magda-csw-connector/aspect-templates/organization-source.js
@@ -2,6 +2,7 @@ const csw = libraries.csw;
 
 return {
     type: 'csw-organization',
-    url: csw.baseUrl,
+    url: csw.baseUrl.toString(),
+    id: csw.id,
     name: csw.name
 };

--- a/magda-csw-connector/src/Csw.ts
+++ b/magda-csw-connector/src/Csw.ts
@@ -12,6 +12,7 @@ import { groupBy } from 'lodash';
 
 export default class Csw implements ConnectorSource {
     public readonly baseUrl: uri.URI;
+    public readonly id: string;
     public readonly name: string;
     public readonly pageSize: number;
     public readonly maxRetries: number;
@@ -23,11 +24,13 @@ export default class Csw implements ConnectorSource {
 
     constructor(options: CswOptions) {
         this.baseUrl = new URI(options.baseUrl);
+        this.id = options.id;
         this.name = options.name;
         this.pageSize = options.pageSize || 10;
         this.maxRetries = options.maxRetries || 10;
         this.secondsBetweenRetries = options.secondsBetweenRetries || 10;
         this.urlBuilder = new CswUrlBuilder({
+            id: options.id,
             name: options.name,
             baseUrl: options.baseUrl
         });
@@ -206,6 +209,7 @@ export default class Csw implements ConnectorSource {
 
 export interface CswOptions {
     baseUrl: string;
+    id: string;
     name: string;
     pageSize?: number;
     maxRetries?: number;

--- a/magda-csw-connector/src/CswTransformer.ts
+++ b/magda-csw-connector/src/CswTransformer.ts
@@ -1,24 +1,25 @@
 import JsonTransformer, { JsonTransformerOptions } from '@magda/typescript-common/dist/JsonTransformer';
-import * as crypto from 'crypto';
 import * as jsonpath from 'jsonpath';
+import ConnectorRecordId from '@magda/typescript-common/dist/ConnectorRecordId';
 
 export default class CswTransformer extends JsonTransformer {
     constructor(options: JsonTransformerOptions) {
         super(options);
     }
 
-    getIdFromJsonOrganization(jsonOrganization: any): string {
+    getIdFromJsonOrganization(jsonOrganization: any, sourceId: string): ConnectorRecordId {
         const name = this.getNameFromJsonOrganization(jsonOrganization);
-        const id = name && name.length > 100 ? crypto.createHash('sha256').update(name, 'utf8').digest('hex') : name;
-        return id
+        return name && name.length > 0 ? new ConnectorRecordId(name, "Organization", sourceId) : undefined;
     }
 
-    getIdFromJsonDataset(jsonDataset: any): string {
-        return jsonDataset.json.fileIdentifier[0].CharacterString[0]._;
+    getIdFromJsonDataset(jsonDataset: any, sourceId: string): ConnectorRecordId {
+        const id = this.getRawDatasetId(jsonDataset);
+        return id && id.length > 0 ? new ConnectorRecordId(id, "Dataset", sourceId) : undefined;
     }
 
-    getIdFromJsonDistribution(jsonDistribution: any, jsonDataset: any): string {
-        return this.getIdFromJsonDataset(jsonDataset) + '-' + this.getJsonDistributionsArray(jsonDataset).indexOf(jsonDistribution);
+    getIdFromJsonDistribution(jsonDistribution: any, jsonDataset: any, sourceId: string): ConnectorRecordId {
+        const id = this.getRawDistributionId(jsonDistribution, jsonDataset);
+        return id && id.length > 0 ? new ConnectorRecordId(id, "Distribution", sourceId) : undefined;
     }
 
     getNameFromJsonOrganization(jsonOrganization: any): string {
@@ -29,17 +30,25 @@ export default class CswTransformer extends JsonTransformer {
         const dataIdentification = jsonpath.query(jsonDataset.json, '$.identificationInfo[*].MD_DataIdentification[*].dataIdentification[*]');
         const serviceIdentification = jsonpath.query(jsonDataset.json, '$.identificationInfo[*].SV_ServiceIdentification[*].serviceIdentification[*]');
         const identification = dataIdentification || serviceIdentification || {};
-        const title = jsonpath.value(identification, '$.citation[*].CI_Citation[*].title[*].CharacterString[*]._') || this.getIdFromJsonDataset(jsonDataset);
+        const title = jsonpath.value(identification, '$.citation[*].CI_Citation[*].title[*].CharacterString[*]._') || this.getRawDatasetId(jsonDataset);
         return title;
     }
 
     getNameFromJsonDistribution(jsonDistribution: any, jsonDataset: any): string {
         const name = jsonpath.value(jsonDistribution, '$.name[*].CharacterString[*]._');
         const description = jsonpath.value(jsonDistribution, '$.description[*].CharacterString[*]._');
-        return name || description || this.getIdFromJsonDistribution(jsonDistribution, jsonDataset);
+        return name || description || this.getRawDistributionId(jsonDistribution, jsonDataset);
     }
 
     private getJsonDistributionsArray(dataset: any): any[] {
         return jsonpath.query(dataset.json, '$.distributionInfo[*].MD_Distribution[*].transferOptions[*].MD_DigitalTransferOptions[*].onLine[*].CI_OnlineResource[*]');
+    }
+
+    private getRawDatasetId(jsonDataset: any): string {
+        return jsonDataset.json.fileIdentifier[0].CharacterString[0]._;
+    }
+
+    private getRawDistributionId(jsonDistribution: any, jsonDataset: any): string {
+        return this.getRawDatasetId(jsonDataset) + '-' + this.getJsonDistributionsArray(jsonDataset).indexOf(jsonDistribution);
     }
 }

--- a/magda-csw-connector/src/CswUrlBuilder.ts
+++ b/magda-csw-connector/src/CswUrlBuilder.ts
@@ -1,12 +1,14 @@
 import * as URI from 'urijs';
 
 export interface CswUrlBuilderOptions {
+    id: string,
     name?: string,
     baseUrl: string;
     apiBaseUrl?: string;
 }
 
 export default class CswUrlBuilder {
+    public readonly id: string;
     public readonly name: string;
     public readonly baseUrl: uri.URI;
 
@@ -32,7 +34,8 @@ export default class CswUrlBuilder {
     };
 
     constructor(options: CswUrlBuilderOptions) {
-        this.name = options.name || 'CSW';
+        this.id = options.id;
+        this.name = options.name || options.id;
         this.baseUrl = new URI(options.baseUrl);
     }
 

--- a/magda-csw-connector/src/createTransformer.ts
+++ b/magda-csw-connector/src/createTransformer.ts
@@ -7,6 +7,7 @@ import * as lodash from 'lodash';
 import * as jsonpath from 'jsonpath';
 
 export interface CreateTransformerOptions {
+    id: string,
     name: string,
     sourceUrl: string,
     datasetAspectBuilders: AspectBuilder[],
@@ -15,6 +16,7 @@ export interface CreateTransformerOptions {
 }
 
 export default function createTransformer({
+    id,
     name,
     sourceUrl,
     datasetAspectBuilders,
@@ -22,6 +24,7 @@ export default function createTransformer({
     organizationAspectBuilders
 }: CreateTransformerOptions) {
     return new CswTransformer({
+        sourceId: id,
         datasetAspectBuilders: datasetAspectBuilders,
         distributionAspectBuilders: distributionAspectBuilders,
         organizationAspectBuilders: organizationAspectBuilders,
@@ -31,6 +34,7 @@ export default function createTransformer({
             lodash: lodash,
             jsonpath: jsonpath,
             csw: new CswUrlBuilder({
+                id: id,
                 name: name,
                 baseUrl: sourceUrl
             })

--- a/magda-csw-connector/src/index.ts
+++ b/magda-csw-connector/src/index.ts
@@ -12,6 +12,12 @@ const argv = addJwtSecretFromEnvVar(
     yargs
         .config()
         .help()
+        .option("id", {
+            describe:
+                "The ID of this connector. Datasets created by this connector will have an ID prefixed with this ID.",
+            type: "string",
+            demandOption: true
+        })
         .option("name", {
             describe:
                 "The name of this connector, to be displayed to users to indicate the source of datasets.",
@@ -66,6 +72,7 @@ const argv = addJwtSecretFromEnvVar(
 );
 
 const csw = new Csw({
+    id: argv.id,
     baseUrl: argv.sourceUrl,
     name: argv.name,
     pageSize: argv.pageSize
@@ -78,6 +85,7 @@ const registry = new Registry({
 });
 
 const transformerOptions = {
+    id: argv.id,
     name: argv.name,
     sourceUrl: argv.sourceUrl,
     pageSize: argv.pageSize,

--- a/magda-project-open-data-connector/aspect-templates/dataset-source.js
+++ b/magda-project-open-data-connector/aspect-templates/dataset-source.js
@@ -3,5 +3,6 @@ var projectOpenData = libraries.projectOpenData;
 return {
     type: 'project-open-data-dataset',
     url: projectOpenData.url,
+    id: projectOpenData.id,
     name: projectOpenData.name
 };

--- a/magda-project-open-data-connector/aspect-templates/distribution-source.js
+++ b/magda-project-open-data-connector/aspect-templates/distribution-source.js
@@ -3,5 +3,6 @@ var projectOpenData = libraries.projectOpenData;
 return {
     type: 'project-open-data-distribution',
     url: projectOpenData.url,
+    id: projectOpenData.id,
     name: projectOpenData.name
 };

--- a/magda-project-open-data-connector/aspect-templates/organization-source.js
+++ b/magda-project-open-data-connector/aspect-templates/organization-source.js
@@ -3,5 +3,6 @@ var projectOpenData = libraries.projectOpenData;
 return {
     type: 'project-open-data-organization',
     url: projectOpenData.url,
+    id: projectOpenData.id,
     name: projectOpenData.name
 };

--- a/magda-project-open-data-connector/src/ProjectOpenData.ts
+++ b/magda-project-open-data-connector/src/ProjectOpenData.ts
@@ -5,12 +5,17 @@ import retry from '@magda/typescript-common/dist/retry';
 import * as request from 'request';
 
 export default class ProjectOpenData implements ConnectorSource {
+    public readonly id: string;
+    public readonly name: string;
+
     private url: string;
     private secondsBetweenRetries: number;
     private maxRetries: number;
     private dataPromise: Promise<object>;
 
     constructor(options: ProjectOpenDataOptions) {
+        this.id = options.id;
+        this.name = options.name;
         this.url = options.url;
         this.secondsBetweenRetries = options.secondsBetweenRetries || 10;
         this.maxRetries = options.maxRetries || 10;
@@ -105,6 +110,7 @@ export default class ProjectOpenData implements ConnectorSource {
 }
 
 export interface ProjectOpenDataOptions {
+    id: string,
     name: string,
     url: string,
     secondsBetweenRetries?: number;

--- a/magda-project-open-data-connector/src/ProjectOpenDataTransformer.ts
+++ b/magda-project-open-data-connector/src/ProjectOpenDataTransformer.ts
@@ -1,20 +1,21 @@
 import JsonTransformer, { JsonTransformerOptions } from '@magda/typescript-common/dist/JsonTransformer';
+import ConnectorRecordId from '@magda/typescript-common/dist/ConnectorRecordId';
 
 export default class ProjectOpenDataTransformer extends JsonTransformer {
     constructor(options: JsonTransformerOptions) {
         super(options);
     }
 
-    getIdFromJsonOrganization(jsonOrganization: any): string {
-        return jsonOrganization.name;
+    getIdFromJsonOrganization(jsonOrganization: any, sourceId: string): ConnectorRecordId {
+        return new ConnectorRecordId(jsonOrganization.name, "Organization", sourceId);
     }
 
-    getIdFromJsonDataset(jsonDataset: any): string {
-        return jsonDataset.identifier;
+    getIdFromJsonDataset(jsonDataset: any, sourceId: string): ConnectorRecordId {
+        return new ConnectorRecordId(jsonDataset.identifier, "Dataset", sourceId);
     }
 
-    getIdFromJsonDistribution(jsonDistribution: any, jsonDataset: any): string {
-        return jsonDataset.identifier + '-' + jsonDataset.distribution.indexOf(jsonDistribution);
+    getIdFromJsonDistribution(jsonDistribution: any, jsonDataset: any, sourceId: string): ConnectorRecordId {
+        return new ConnectorRecordId(this.getRawDistributionId(jsonDistribution, jsonDataset), "Distribution", sourceId);
     }
 
     getNameFromJsonOrganization(jsonOrganization: any): string {
@@ -26,6 +27,10 @@ export default class ProjectOpenDataTransformer extends JsonTransformer {
     }
 
     getNameFromJsonDistribution(jsonDistribution: any, jsonDataset: any): string {
-        return jsonDistribution.title || this.getIdFromJsonDistribution(jsonDistribution, jsonDataset);
+        return jsonDistribution.title || this.getRawDistributionId(jsonDistribution, jsonDataset);
+    }
+
+    private getRawDistributionId(jsonDistribution: any, jsonDataset: any): string {
+        return jsonDataset.identifier + '-' + jsonDataset.distribution.indexOf(jsonDistribution);
     }
 }

--- a/magda-project-open-data-connector/src/createTransformer.ts
+++ b/magda-project-open-data-connector/src/createTransformer.ts
@@ -4,6 +4,7 @@ import * as moment from 'moment';
 import * as URI from 'urijs';
 
 export interface CreateTransformerOptions {
+    id: string,
     name: string,
     sourceUrl: string,
     datasetAspectBuilders: AspectBuilder[],
@@ -12,6 +13,7 @@ export interface CreateTransformerOptions {
 }
 
 export default function createTransformer({
+    id,
     name,
     sourceUrl,
     datasetAspectBuilders,
@@ -19,6 +21,7 @@ export default function createTransformer({
     organizationAspectBuilders
 }: CreateTransformerOptions) {
     return new ProjectOpenDataTransformer({
+        sourceId: id,
         datasetAspectBuilders: datasetAspectBuilders,
         distributionAspectBuilders: distributionAspectBuilders,
         organizationAspectBuilders: organizationAspectBuilders,
@@ -26,6 +29,7 @@ export default function createTransformer({
             moment: moment,
             URI: URI,
             projectOpenData: Object.freeze({
+                id: id,
                 name: name,
                 url: sourceUrl
             })

--- a/magda-project-open-data-connector/src/index.ts
+++ b/magda-project-open-data-connector/src/index.ts
@@ -12,6 +12,12 @@ const argv = addJwtSecretFromEnvVar(
     yargs
         .config()
         .help()
+        .option("id", {
+            describe:
+                "The ID of this connector. Datasets created by this connector will have an ID prefixed with this ID.",
+            type: "string",
+            demandOption: true
+        })
         .option("name", {
             describe:
                 "The name of this connector, to be displayed to users to indicate the source of datasets.",
@@ -59,6 +65,7 @@ const argv = addJwtSecretFromEnvVar(
 );
 
 const source = new ProjectOpenData({
+    id: argv.id,
     name: argv.name,
     url: argv.sourceUrl,
 });
@@ -70,6 +77,7 @@ const registry = new Registry({
 });
 
 const transformerOptions = {
+    id: argv.id,
     name: argv.name,
     sourceUrl: argv.sourceUrl,
     registryUrl: argv.registryUrl,

--- a/magda-typescript-common/src/AspectCreationFailure.ts
+++ b/magda-typescript-common/src/AspectCreationFailure.ts
@@ -1,0 +1,3 @@
+export default class AspectCreationFailure {
+    constructor(readonly id: string, readonly error: Error) {}
+}

--- a/magda-typescript-common/src/ConnectionResult.ts
+++ b/magda-typescript-common/src/ConnectionResult.ts
@@ -1,4 +1,5 @@
-import CreationFailure from './CreationFailure';
+import AspectCreationFailure from './AspectCreationFailure';
+import RecordCreationFailure from './RecordCreationFailure';
 
 export default class ConnectionResult {
     public aspectDefinitionsConnected = 0;
@@ -6,10 +7,10 @@ export default class ConnectionResult {
     public datasetsConnected = 0;
     public distributionsConnected = 0;
 
-    public aspectDefinitionFailures = Array<CreationFailure>();
-    public organizationFailures = Array<CreationFailure>();
-    public datasetFailures = Array<CreationFailure>();
-    public distributionFailures = Array<CreationFailure>();
+    public aspectDefinitionFailures = Array<AspectCreationFailure>();
+    public organizationFailures = Array<RecordCreationFailure>();
+    public datasetFailures = Array<RecordCreationFailure>();
+    public distributionFailures = Array<RecordCreationFailure>();
 
     public summarize(): string {
         let result = '';

--- a/magda-typescript-common/src/ConnectorRecordId.ts
+++ b/magda-typescript-common/src/ConnectorRecordId.ts
@@ -1,0 +1,21 @@
+export const RecordTypeMapping = {
+    "Organization": "org",
+    "Dataset": "ds",
+    "Distribution": "dist"
+};
+
+export default class ConnectorRecordId {
+    constructor(
+        readonly id: string,
+        readonly type: "Organization" | "Dataset" | "Distribution",
+        readonly sourceId: string) {
+    }
+
+    toString(): string {
+        return [this.typeId, this.sourceId, this.id].join('-');
+    }
+
+    private get typeId(): string {
+        return RecordTypeMapping[this.type];
+    }
+}

--- a/magda-typescript-common/src/ConnectorRecordId.ts
+++ b/magda-typescript-common/src/ConnectorRecordId.ts
@@ -1,3 +1,5 @@
+import * as crypto from 'crypto';
+
 export const RecordTypeMapping = {
     "Organization": "org",
     "Dataset": "ds",
@@ -12,7 +14,19 @@ export default class ConnectorRecordId {
     }
 
     toString(): string {
-        return [this.typeId, this.sourceId, this.id].join('-');
+        const id = [this.typeId, this.sourceId, this.id].join('-');
+        if (id.length > 100) {
+            // ID is too long, so hash the source record ID.
+            const hashedId = crypto.createHash('sha256').update(this.id, 'utf8').digest('hex');
+            const hashedFullId = [this.typeId, this.sourceId, hashedId].join('-');
+            if (hashedFullId.length > 100) {
+                // It's _still_ too long, probably because the sourceId is excessively long.
+                // So hash the full ID, including the sourceId and typeId.
+                return crypto.createHash('sha256').update(id, 'utf8').digest('hex');
+            }
+            return hashedFullId;
+        }
+        return id;
     }
 
     private get typeId(): string {

--- a/magda-typescript-common/src/CreationFailure.ts
+++ b/magda-typescript-common/src/CreationFailure.ts
@@ -1,3 +1,0 @@
-export default class CreationFailure {
-    constructor(readonly id: string, readonly parentId: string, readonly error: Error) {}
-}

--- a/magda-typescript-common/src/CreationFailuresError.ts
+++ b/magda-typescript-common/src/CreationFailuresError.ts
@@ -1,7 +1,0 @@
-import CreationFailure from './CreationFailure';
-
-export default class CreationFailuresError extends Error {
-    constructor(readonly failures: CreationFailure[]) {
-        super('One or more aspect definitions could not be created.');
-    }
-}

--- a/magda-typescript-common/src/JsonTransformer.ts
+++ b/magda-typescript-common/src/JsonTransformer.ts
@@ -107,13 +107,13 @@ export default abstract class JsonTransformer {
         ]);
     }
 
-    abstract getIdFromJsonOrganization(jsonOrganization: object, sourceId: string): ConnectorRecordId;
-    abstract getIdFromJsonDataset(jsonDataset: object, sourceId: string): ConnectorRecordId;
-    abstract getIdFromJsonDistribution(jsonDistribution: object, jsonDataset: object, sourceId: string): ConnectorRecordId;
+    abstract getIdFromJsonOrganization(jsonOrganization: any, sourceId: string): ConnectorRecordId;
+    abstract getIdFromJsonDataset(jsonDataset: any, sourceId: string): ConnectorRecordId;
+    abstract getIdFromJsonDistribution(jsonDistribution: any, jsonDataset: any, sourceId: string): ConnectorRecordId;
 
-    abstract getNameFromJsonOrganization(jsonOrganization: object): string;
-    abstract getNameFromJsonDataset(jsonDataset: object): string;
-    abstract getNameFromJsonDistribution(jsonDistribution: object, jsonDataset: object): string;
+    abstract getNameFromJsonOrganization(jsonOrganization: any): string;
+    abstract getNameFromJsonDataset(jsonDataset: any): string;
+    abstract getNameFromJsonDistribution(jsonDistribution: any, jsonDataset: any): string;
 
     private jsonToRecord(id: ConnectorRecordId, name: string, json: any, aspects: CompiledAspects): Record {
         const problems: ProblemReport[] = [];

--- a/magda-typescript-common/src/JsonTransformer.ts
+++ b/magda-typescript-common/src/JsonTransformer.ts
@@ -1,5 +1,6 @@
 import { AspectDefinition, Record } from './generated/registry/api';
 import AspectBuilder from './AspectBuilder';
+import ConnectorRecordId from './ConnectorRecordId';
 import createServiceError from './createServiceError';
 
 /**
@@ -7,7 +8,7 @@ import createServiceError from './createServiceError';
  * A transformer takes source data and transforms it to registry records and aspects.
  */
 export default abstract class JsonTransformer {
-    private libraries: object;
+    private sourceId: string;
     private datasetAspectBuilders: AspectBuilder[];
     private distributionAspectBuilders: AspectBuilder[];
     private organizationAspectBuilders: AspectBuilder[];
@@ -16,12 +17,13 @@ export default abstract class JsonTransformer {
     private distributionAspects: CompiledAspects;
 
     constructor({
+        sourceId,
         libraries = {},
         datasetAspectBuilders = [],
         distributionAspectBuilders = [],
         organizationAspectBuilders = []
     }: JsonTransformerOptions) {
-        this.libraries = libraries;
+        this.sourceId = sourceId;
         this.datasetAspectBuilders = datasetAspectBuilders.slice();
         this.distributionAspectBuilders = distributionAspectBuilders.slice();
         this.organizationAspectBuilders = organizationAspectBuilders.slice();
@@ -61,7 +63,7 @@ export default abstract class JsonTransformer {
     organizationJsonToRecord(jsonOrganization: object): Record {
         this.organizationAspects.parameters.organization = jsonOrganization;
 
-        const id = this.getIdFromJsonOrganization(jsonOrganization);
+        const id = this.getIdFromJsonOrganization(jsonOrganization, this.sourceId);
         const name = this.getNameFromJsonOrganization(jsonOrganization);
         return this.jsonToRecord(id, name, jsonOrganization, this.organizationAspects);
     }
@@ -69,7 +71,7 @@ export default abstract class JsonTransformer {
     datasetJsonToRecord(jsonDataset: object): Record {
         this.datasetAspects.parameters.dataset = jsonDataset;
 
-        const id = this.getIdFromJsonDataset(jsonDataset);
+        const id = this.getIdFromJsonDataset(jsonDataset, this.sourceId);
         const name = this.getNameFromJsonDataset(jsonDataset);
         return this.jsonToRecord(id, name, jsonDataset, this.datasetAspects);
     }
@@ -78,7 +80,7 @@ export default abstract class JsonTransformer {
         this.distributionAspects.parameters.dataset = jsonDataset;
         this.distributionAspects.parameters.distribution = jsonDistribution;
 
-        const id = this.getIdFromJsonDistribution(jsonDistribution, jsonDataset);
+        const id = this.getIdFromJsonDistribution(jsonDistribution, jsonDataset, this.sourceId);
         const name = this.getNameFromJsonDistribution(jsonDistribution, jsonDataset);
         return this.jsonToRecord(id, name, jsonDistribution, this.distributionAspects);
     }
@@ -105,15 +107,15 @@ export default abstract class JsonTransformer {
         ]);
     }
 
-    abstract getIdFromJsonOrganization(jsonOrganization: object): string;
-    abstract getIdFromJsonDataset(jsonDataset: object): string;
-    abstract getIdFromJsonDistribution(jsonDistribution: object, jsonDataset: object): string;
+    abstract getIdFromJsonOrganization(jsonOrganization: object, sourceId: string): ConnectorRecordId;
+    abstract getIdFromJsonDataset(jsonDataset: object, sourceId: string): ConnectorRecordId;
+    abstract getIdFromJsonDistribution(jsonDistribution: object, jsonDataset: object, sourceId: string): ConnectorRecordId;
 
     abstract getNameFromJsonOrganization(jsonOrganization: object): string;
     abstract getNameFromJsonDataset(jsonDataset: object): string;
     abstract getNameFromJsonDistribution(jsonDistribution: object, jsonDataset: object): string;
 
-    private jsonToRecord(id: string, name: string, json: any, aspects: CompiledAspects): Record {
+    private jsonToRecord(id: ConnectorRecordId, name: string, json: any, aspects: CompiledAspects): Record {
         const problems: ProblemReport[] = [];
 
         function reportProblem(title: string, message?: string, additionalInfo?: any) {
@@ -147,7 +149,7 @@ export default abstract class JsonTransformer {
         }
 
         return {
-            id: id,
+            id: id.toString(),
             name: name,
             aspects: generatedAspects
         };
@@ -181,7 +183,8 @@ function buildersToCompiledAspects(builders: AspectBuilder[], setupParameters: B
 }
 
 export interface JsonTransformerOptions {
-    libraries: object,
+    sourceId: string,
+    libraries?: object,
     datasetAspectBuilders?: AspectBuilder[],
     distributionAspectBuilders?: AspectBuilder[],
     organizationAspectBuilders?: AspectBuilder[],

--- a/magda-typescript-common/src/RecordCreationFailure.ts
+++ b/magda-typescript-common/src/RecordCreationFailure.ts
@@ -1,0 +1,5 @@
+import ConnectorRecordId from "./ConnectorRecordId";
+
+export default class RecordCreationFailure {
+    constructor(readonly id: ConnectorRecordId, readonly parentId: ConnectorRecordId, readonly error: Error) {}
+}


### PR DESCRIPTION
* Connectors now create organizations, datasets, and distributions with IDs prefixed by the type of record and by the ID of the connector. For example, `org-bom-Australian Bureau of Meteorology` is the organization with the ID `Australian Bureau of Meteorology` from the connector with ID `bom`. Other type prefixes are `ds` for dataset and `dist` for distribution. This change avoids conflicting IDs from different sources.
* Fixed a race condition in the registry that could lead to an error when multiple requests tried to create/update the same record simultaneously, which is fairly common when creating organizations in the CSW connector.

Fixes #122 
