### PR TITLE
Update docker-registry.yml for chart v0.3.0

### DIFF
--- a/deploy/helm/docker-registry.yml
+++ b/deploy/helm/docker-registry.yml
@@ -1,3 +1,5 @@
 persistentVolume:
   enabled: true
   storageClass: standard
+service:
+  port: 4000


### PR DESCRIPTION
Relevant change that breaks our config, and requires `service.port` to be set: https://github.com/kubernetes/charts/commit/568519e1b161f814d34cc6266f4265ea6fe8c140#diff-917edb4d09b2b3caaccfcc1605d34e09

Might also require `minikube delete` and a new `minikube start` (mine did).
