### PR TITLE
Don't use the name of the SA2 that contains it as the name of SA1s

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,3 +2,4 @@
 
 * Connectors now create organizations, datasets, and distributions with IDs prefixed by the type of record and by the ID of the connector. For example, `org-bom-Australian Bureau of Meteorology` is the organization with the ID `Australian Bureau of Meteorology` from the connector with ID `bom`. Other type prefixes are `ds` for dataset and `dist` for distribution. This change avoids conflicting IDs from different sources.
 * Fixed a race condition in the registry that could lead to an error when multiple requests tried to create/update the same record simultaneously, which is fairly common when creating organizations in the CSW connector.
+* SA1 regions are no longer named after the SA2 region that contains them, reducing noise in the region search results. To find an actual SA1, users will need to search for its ID.

--- a/magda-scala-common/src/main/resources/common.conf
+++ b/magda-scala-common/src/main/resources/common.conf
@@ -3,7 +3,7 @@ elasticSearch {
 
   indices {
     regions {
-      version = 18
+      version = 20
     }
 
     datasets {

--- a/magda-scala-common/src/main/resources/common.conf
+++ b/magda-scala-common/src/main/resources/common.conf
@@ -42,8 +42,8 @@ regionSources = {
 	SA1 {
 		url = "https://s3-ap-southeast-2.amazonaws.com/magda-files/SA1.geojson"
 		idField = "SA1_MAIN11"
-		nameField = "SA2_NAME11",
-		includeIdInName = true,
+		nameField = "SA1_MAIN11",
+		includeIdInName = false,
 		order = 60
 	}
 	LGA {

--- a/magda-scala-common/src/main/resources/common.conf
+++ b/magda-scala-common/src/main/resources/common.conf
@@ -3,7 +3,7 @@ elasticSearch {
 
   indices {
     regions {
-      version = 17
+      version = 18
     }
 
     datasets {

--- a/magda-scala-common/src/main/scala/au/csiro/data61/magda/search/elasticsearch/IndexDefinition.scala
+++ b/magda-scala-common/src/main/scala/au/csiro/data61/magda/search/elasticsearch/IndexDefinition.scala
@@ -118,7 +118,7 @@ object IndexDefinition extends DefaultJsonProtocol {
   val regions: IndexDefinition =
     new IndexDefinition(
       name = "regions",
-      version = 17,
+      version = 20,
       indicesIndex = Indices.RegionsIndex,
       definition = (indices, config) =>
         create.index(indices.getIndex(config, Indices.RegionsIndex))


### PR DESCRIPTION
To reduce clutter in region search results.

To find SA1s, users will need to search for the region's ID, because SA1s don't have friendly names.