### PR TITLE
Added separate externalRetries config to broken link sleuther.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,3 +5,4 @@
 * Updated hooks so that each hook when running can skip over irrelevant events
 * Made sure hook processing resumes when either the registry or the sleuther wakes back up.
 * SA1 regions are no longer named after the SA2 region that contains them, reducing noise in the region search results. To find an actual SA1, users will need to search for its ID.
+* The broken link sleuther now has its retry count for external links configurable separately to the retry count for contacting the registry, with a default of 3.

--- a/deploy/helm/magda/values.yaml
+++ b/deploy/helm/magda/values.yaml
@@ -6,7 +6,6 @@ global:
   exposeNodePorts: false
   image:
     repository: "data61"
-    tag: "0.0.29"
     pullPolicy: Always
   defaultAdminUserId: "00000000-0000-4000-8000-000000000000"
   logLevel: INFO

--- a/magda-sleuther-broken-link/src/index.ts
+++ b/magda-sleuther-broken-link/src/index.ts
@@ -6,7 +6,14 @@ import commonYargs from "@magda/sleuther-framework/dist/commonYargs";
 
 const ID = "sleuther-broken-link";
 
-const argv = commonYargs(ID, 6111, "http://localhost:6111");
+const argv = commonYargs(ID, 6111, "http://localhost:6111", argv =>
+    argv.option("externalRetries", {
+        describe:
+            "Number of times to retry external links when checking whether they're broken",
+        type: "number",
+        default: 3
+    })
+);
 
 function sleuthBrokenLinks() {
     return sleuther({
@@ -17,7 +24,7 @@ function sleuthBrokenLinks() {
         async: true,
         writeAspectDefs: [brokenLinkAspectDef, datasetQualityAspectDef],
         onRecordFound: (record, registry) =>
-            onRecordFound(record, registry, argv.retries)
+            onRecordFound(record, registry, argv.externalRetries)
     });
 }
 


### PR DESCRIPTION
Fixes #345 

### What this PR does
This separates the retry count for checking external links in the broken link sleuther from the retry count for contacting the registry, defaulting to 3. Right now the sleuther tries to retry every failed link 10 times - with the backoff, this means a failed link takes a really really long time to be checked completely. This speeds things up.

### Checklist
- [x] There are unit tests to verify my changes are correct (or unit tests aren't applicable)
- [x] I've updated CHANGES.md with what I changed.
