### PR TITLE
Reduce CPU Usage When Processing Hooks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,3 +6,6 @@
 * Made sure hook processing resumes when either the registry or the sleuther wakes back up.
 * SA1 regions are no longer named after the SA2 region that contains them, reducing noise in the region search results. To find an actual SA1, users will need to search for its ID.
 * The broken link sleuther now has its retry count for external links configurable separately to the retry count for contacting the registry, with a default of 3.
+* Optimised the query that finds new events for each webhook
+* Stopped async webhooks posting `success: false` on an uncaught failure, as this just causes them to process the same data and fail over and over.
+* Stopped the broken link sleuther from failing completely when it gets a string that isn't a valid URL - now records as "broken".

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/EventsPage.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/EventsPage.scala
@@ -1,18 +1,12 @@
 package au.csiro.data61.magda.registry
 
-import io.swagger.annotations.{ApiModel, ApiModelProperty}
+import io.swagger.annotations.{ ApiModel, ApiModelProperty }
 import au.csiro.data61.magda.model.Registry._
 
 import scala.annotation.meta.field
 
 @ApiModel(description = "A page of events.")
 case class EventsPage(
-  @(ApiModelProperty @field)(value = "The total number of events available.", required = true)
-  totalCount: Int,
+  @(ApiModelProperty @field)(value = "A token to be used to get the next page of events.", required = true) nextPageToken: Option[String],
 
-  @(ApiModelProperty @field)(value = "A token to be used to get the next page of events.", required = true)
-  nextPageToken: Option[String],
-
-  @(ApiModelProperty @field)(value = "The events in this page.", required = true)
-  events: List[RegistryEvent]
-)
+  @(ApiModelProperty @field)(value = "The events in this page.", required = true) events: List[RegistryEvent])

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/HooksService.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/HooksService.scala
@@ -127,7 +127,7 @@ class HooksService(config: Config, webHookActor: ActorRef, authClient: AuthApiCl
     new ApiImplicitParam(name = "X-Magda-Session", required = true, dataType = "String", paramType = "header", value = "Magda internal session id")))
   def ack = post {
     path(Segment / "ack") { (id: String) =>
-      entity(as[WebHookAcknowledgement]) { acknowledgement =>
+      entity(as[WebHookAcknowledgement]) { acknowledgement =>        
         val result = DB localTx { session =>
           HookPersistence.acknowledgeRaisedHook(session, id, acknowledgement) match {
             case Success(result)    => complete(result)

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/Protocols.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/Protocols.scala
@@ -18,6 +18,6 @@ trait Protocols extends DiffsonProtocol with CommonRegistryProtocols {
   implicit val recordsPageFormat = jsonFormat3(RecordsPage.apply)
   implicit val recordSummariesPageFormat = jsonFormat3(RecordSummariesPage.apply)
   implicit val deleteResultFormat = jsonFormat1(DeleteResult.apply)
-  implicit val eventsPageFormat = jsonFormat3(EventsPage.apply)
+  implicit val eventsPageFormat = jsonFormat2(EventsPage.apply)
   implicit val webHookResponseFormat = jsonFormat1(WebHookResponse.apply)
 }

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/WebHookActor.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/WebHookActor.scala
@@ -17,6 +17,7 @@ import akka.stream.scaladsl.SourceQueueWithComplete
 import akka.stream.DelayOverflowStrategy
 import akka.stream.Attributes
 import com.typesafe.config.Config
+import akka.actor.ActorContext
 
 object WebHookActor {
   case class Process(ignoreWaitingForResponse: Boolean = false, aspectIds: Option[List[String]] = None, webHookId: Option[String] = None)
@@ -27,8 +28,8 @@ object WebHookActor {
 
   def props(registryApiBaseUrl: String)(implicit config: Config) = Props(new AllWebHooksActor(registryApiBaseUrl))
 
-  private def createWebHookActor(system: ActorSystem, registryApiBaseUrl: String, hook: WebHook)(implicit config: Config): ActorRef = {
-    system.actorOf(Props(new SingleWebHookActor(hook.id.get, registryApiBaseUrl)), name = "WebHookActor-" + java.net.URLEncoder.encode(hook.id.get, "UTF-8") + "-" + java.util.UUID.randomUUID.toString)
+  private def createWebHookActor(context: ActorContext, registryApiBaseUrl: String, hook: WebHook)(implicit config: Config): ActorRef = {
+    context.actorOf(Props(new SingleWebHookActor(hook.id.get, registryApiBaseUrl)), name = "WebHookActor-" + java.net.URLEncoder.encode(hook.id.get, "UTF-8") + "-" + java.util.UUID.randomUUID.toString)
   }
 
   private case class GotAllWebHooks(webHooks: List[WebHook], startup: Boolean)
@@ -69,7 +70,7 @@ object WebHookActor {
               case Some(actorRef) => actorRef
               case None => {
                 log.info("Creating new web hook actor for {}.", id)
-                val actorRef = WebHookActor.createWebHookActor(context.system, registryApiBaseUrl, hook)
+                val actorRef = WebHookActor.createWebHookActor(context, registryApiBaseUrl, hook)
                 this.webHookActors += (id -> actorRef)
                 actorRef
               }
@@ -80,7 +81,9 @@ object WebHookActor {
     setup
 
     def receive = {
-      case InvalidateWebhookCache => setup
+      case InvalidateWebhookCache => 
+        println("invalidated")
+        setup
       case Process(ignoreWaitingForResponse, aspectIds, webHookId) => {
         val actors = webHookId match {
           case None                 => webHookActors.values
@@ -163,9 +166,13 @@ object WebHookActor {
                     if (previousLastEvent != lastEvent) {
                       self ! Process()
                     }
+                  case WebHookProcessor.HttpError(status) =>
+                    // encountered an error while communicating with the hook recipient - deactivate the hook until its manually fixed
+                    log.info("WebHook {} Processing {}-{}: HTTP FAILURE {}, DEACTIVATING", this.id, previousLastEvent, lastEvent, status.reason())
+                    context.parent ! InvalidateWebhookCache
                 }.recover {
                   case e =>
-                    // TODO: What should we actually do here? Retry forever? Backoff? Notify someone? :|
+                    // Error communicating with the hook recipient - log the failure and wait until the next Process() call to resume.
                     log.error(e, "WebHook {} Processing {}-{}: FAILED", this.id, previousLastEvent, lastEvent)
                 }
               }

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/WebHookProcessor.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/WebHookProcessor.scala
@@ -96,7 +96,7 @@ class WebHookProcessor(actorSystem: ActorSystem, val publicUrl: Uri, implicit va
 
     val payload = WebHookPayload(
       action = "records.changed",
-      lastEventId = eventPage.events.lastOption.flatMap(_.id).orElse(webHook.lastEvent).get, //if (events.isEmpty) webHook.lastEvent.get else events.last.id.get,
+      lastEventId = eventPage.events.lastOption.flatMap(_.id).get, //if (events.isEmpty) webHook.lastEvent.get else events.last.id.get,
       events = if (webHook.config.includeEvents.getOrElse(true)) Some(changeEvents) else None,
       records = records,
       aspectDefinitions = aspectDefinitions,

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/WebHookProcessor.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/WebHookProcessor.scala
@@ -15,6 +15,7 @@ import au.csiro.data61.magda.model.Registry._
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.concurrent.duration._
 import scala.util.{ Success, Failure }
+import akka.http.scaladsl.model.StatusCode
 
 class WebHookProcessor(actorSystem: ActorSystem, val publicUrl: Uri, implicit val executionContext: ExecutionContext) extends Protocols {
   private val http = Http(actorSystem)
@@ -113,7 +114,12 @@ class WebHookProcessor(actorSystem: ActorSystem, val publicUrl: Uri, implicit va
           case (Success(response), _) => {
             if (response.status.isFailure()) {
               response.discardEntityBytes()
-              Future.failed(new Exception(s"Response from $webHook.url was ${response.status.reason()}"))
+
+              DB localTx { session =>
+                HookPersistence.setActive(session, webHook.id.get, false)
+              }
+
+              Future(WebHookProcessor.HttpError(response.status))
             } else {
               // Try to deserialize the success response as a WebHook response.  It's ok if this fails.
               Unmarshal(response.entity).to[WebHookResponse].map { webHookResponse =>
@@ -153,4 +159,5 @@ object WebHookProcessor {
   sealed trait SendResult
   case object Deferred extends SendResult
   case object NotDeferred extends SendResult
+  case class HttpError(statusCode: StatusCode) extends SendResult
 }

--- a/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/Util.scala
+++ b/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/Util.scala
@@ -37,7 +37,7 @@ object Util {
 
     Util.blockUntil("Hook is finished processing") { () =>
       val result = Await.result(actor ? WebHookActor.GetStatus(hookName), 5 seconds).asInstanceOf[WebHookActor.Status].isProcessing
-      result == Some(false)
+      !result.getOrElse(false)
     }
   }
 }

--- a/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/WebHookProcessingSpec.scala
+++ b/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/WebHookProcessingSpec.scala
@@ -20,6 +20,7 @@ import java.util.UUID
 import gnieh.diffson._
 import gnieh.diffson.sprayJson._
 import org.scalatest.BeforeAndAfterAll
+import akka.pattern.ask
 
 class WebHookProcessingSpec extends ApiSpec with BeforeAndAfterAll {
 
@@ -758,7 +759,7 @@ class WebHookProcessingSpec extends ApiSpec with BeforeAndAfterAll {
         payloads(0).records.get(0).id shouldBe ("dataset")
       }
     }
-    
+
     it("includes a record when an array-linked record is modified") { param =>
       val webHook = defaultWebHook.copy(config = defaultWebHook.config.copy(aspects = Some(List("A"))))
       testWebHook(param, Some(webHook)) { (payloads, actor) =>
@@ -907,7 +908,7 @@ class WebHookProcessingSpec extends ApiSpec with BeforeAndAfterAll {
                 |    }
                 |}
               """.stripMargin
-      val a = AspectDefinition("A", "A", Some(JsonParser(jsonSchema).asJsObject))
+        val a = AspectDefinition("A", "A", Some(JsonParser(jsonSchema).asJsObject))
         param.asAdmin(Post("/v0/aspects", a)) ~> param.api.routes ~> check {
           status shouldEqual StatusCodes.OK
         }
@@ -944,7 +945,7 @@ class WebHookProcessingSpec extends ApiSpec with BeforeAndAfterAll {
         payloads(0).records.get(0).id shouldBe ("dataset")
       }
     }
-    
+
     it("with multiple linking aspects, only one has to link to a modified record") { param =>
       val webHook = defaultWebHook.copy(config = defaultWebHook.config.copy(aspects = Some(List("A", "B"))))
       testWebHook(param, Some(webHook)) { (payloads, actor) =>
@@ -1072,37 +1073,32 @@ class WebHookProcessingSpec extends ApiSpec with BeforeAndAfterAll {
     }
   }
 
-  describe("resumes hooks that have previously failed") {
+  describe("resumes hooks that have previously failed with network errors") {
     describe("sync") {
       val dataset = Record("dataset", "dataset", Map())
 
       def doTestSync(param: FixtureParam)(resumeHook: ArrayBuffer[WebHookPayload] => Any) {
-        var responseCount = 0
-        def response(): ToResponseMarshallable = {
-          responseCount += 1
-
-          if (responseCount == 1) {
-            StatusCodes.NotFound
-          } else {
-            "got it"
+        testWebHook(param, None) { (payloads, actor) =>
+          val url = param.asAdmin(Get("/v0/hooks/test")) ~> param.api.routes ~> check {
+            status shouldEqual StatusCodes.OK
+            responseAs[WebHook].url
           }
-        }
 
-        testWebHookWithResponse(param, Some(defaultWebHook), response) { (payloads, actor) =>
+          param.asAdmin(Put("/v0/hooks/test", defaultWebHook.copy(url = "aerga://bargoiaergoi.aerg"))) ~> param.api.routes ~> check {
+            status shouldEqual StatusCodes.OK
+          }
+
           param.asAdmin(Post("/v0/records", dataset)) ~> param.api.routes ~> check {
             status shouldEqual StatusCodes.OK
           }
 
           Util.waitUntilDone(actor, "test")
 
-          payloads.length shouldBe (1)
-
-          param.asAdmin(Get("/v0/hooks/" + defaultWebHook.id.get)) ~> param.api.routes ~> check {
+          param.asAdmin(Put("/v0/hooks/test", defaultWebHook.copy(url = url))) ~> param.api.routes ~> check {
             status shouldEqual StatusCodes.OK
-            val hook = responseAs[WebHook]
-            hook.lastEvent.get shouldBe (1)
-            payloads.last.lastEventId shouldBe (2)
           }
+
+          payloads.length shouldEqual (0)
 
           resumeHook(payloads)
         }
@@ -1115,7 +1111,7 @@ class WebHookProcessingSpec extends ApiSpec with BeforeAndAfterAll {
           }
 
           Util.waitUntilDone(param.webHookActor, "test")
-          payloads.length shouldBe (2)
+          payloads.length shouldBe (1)
           payloads.last.lastEventId shouldBe (2)
 
           param.asAdmin(Get("/v0/hooks/" + defaultWebHook.id.get)) ~> param.api.routes ~> check {
@@ -1132,7 +1128,7 @@ class WebHookProcessingSpec extends ApiSpec with BeforeAndAfterAll {
 
           Util.waitUntilDone(param.webHookActor, "test")
 
-          payloads.length shouldBe (2)
+          payloads.length shouldBe (1)
           payloads.last.lastEventId shouldBe (2)
         }
       }
@@ -1144,7 +1140,7 @@ class WebHookProcessingSpec extends ApiSpec with BeforeAndAfterAll {
           }
 
           Util.waitUntilDone(param.webHookActor, "test")
-          payloads.length shouldBe (2)
+          payloads.length shouldBe (1)
 
           param.asAdmin(Get("/v0/hooks/" + defaultWebHook.id.get)) ~> param.api.routes ~> check {
             status shouldEqual StatusCodes.OK
@@ -1330,6 +1326,118 @@ class WebHookProcessingSpec extends ApiSpec with BeforeAndAfterAll {
         payloads.last.lastEventId shouldBe >(lastEventId)
         payloads.map(_.aspectDefinitions.get).flatten.length shouldBe 1
         payloads.map(_.aspectDefinitions.get).flatten.head.id shouldBe ("testId2")
+      }
+    }
+
+  }
+
+  describe("deactivation/reactivation") {
+    describe("deactivates on webhook recipient failure") {
+      it("sync - when recipient returns failure code") { param =>
+        def response(): ToResponseMarshallable = {
+          StatusCodes.InternalServerError
+        }
+
+        testWebHookWithResponse(param, Some(defaultWebHook), response) { (payloads, actor) =>
+          param.asAdmin(Get("/v0/hooks/test")) ~> param.api.routes ~> check {
+            status shouldEqual StatusCodes.OK
+            val hook = responseAs[WebHook]
+            hook.active shouldEqual (true)
+          }
+
+          val aspectDefinition = AspectDefinition("testId", "testName", Some(JsObject()))
+          param.asAdmin(Post("/v0/aspects", aspectDefinition)) ~> param.api.routes ~> check {
+            status shouldEqual StatusCodes.OK
+          }
+
+          Util.waitUntilDone(actor, "test")
+
+          payloads.length should be(1)
+
+          param.asAdmin(Get("/v0/hooks/test")) ~> param.api.routes ~> check {
+            status shouldEqual StatusCodes.OK
+            val hook = responseAs[WebHook]
+            hook.active shouldEqual (false)
+          }
+
+          val aspectDefinition2 = AspectDefinition("testId2", "testName2", Some(JsObject()))
+          param.asAdmin(Post("/v0/aspects", aspectDefinition2)) ~> param.api.routes ~> check {
+            status shouldEqual StatusCodes.OK
+          }
+
+          implicit val timeout = Timeout(5 seconds)
+          Await.result(actor ? WebHookActor.GetStatus("test"), 5 seconds).asInstanceOf[WebHookActor.Status].isProcessing.getOrElse(false) shouldEqual (false)
+
+          payloads.length should be(1)
+        }
+      }
+
+      it("async - deactivates when /ack called with active=false") { param =>
+        testAsyncWebHook(param, None) { (payloads, actor) =>
+          val aspectDefinition = AspectDefinition("testId", "testName", Some(JsObject()))
+          param.asAdmin(Post("/v0/aspects", aspectDefinition)) ~> param.api.routes ~> check {
+            status shouldEqual StatusCodes.OK
+          }
+
+          Util.waitUntilDone(actor, "test")
+
+          val lastEventId = payloads(0).lastEventId
+          payloads.clear()
+
+          param.asAdmin(Post("/v0/hooks/test/ack", WebHookAcknowledgement(false, None, Some(false)))) ~> param.api.routes ~> check {
+            status shouldEqual StatusCodes.OK
+            responseAs[WebHookAcknowledgementResponse].lastEventIdReceived should not be (lastEventId)
+          }
+
+          payloads.length shouldEqual (0)
+
+          param.asAdmin(Post("/v0/hooks/test/ack", WebHookAcknowledgement(false))) ~> param.api.routes ~> check {
+            status shouldEqual StatusCodes.OK
+          }
+
+          implicit val timeout = Timeout(5 seconds)
+          Await.result(actor ? WebHookActor.GetStatus("test"), 5 seconds).asInstanceOf[WebHookActor.Status].isProcessing.getOrElse(false) shouldEqual (false)
+
+          payloads.length shouldEqual (0)
+
+          param.asAdmin(Get("/v0/hooks/test")) ~> param.api.routes ~> check {
+            status shouldEqual StatusCodes.OK
+            val hook = responseAs[WebHook]
+            hook.active shouldEqual (false)
+          }
+        }
+      }
+
+      it("reactivates when /ack called with active=true") { param =>
+        testAsyncWebHook(param, Some(defaultWebHook.copy(active = false))) { (payloads, actor) =>
+          val aspectDefinition = AspectDefinition("testId", "testName", Some(JsObject()))
+          param.asAdmin(Post("/v0/aspects", aspectDefinition)) ~> param.api.routes ~> check {
+            status shouldEqual StatusCodes.OK
+          }
+
+          payloads.length shouldEqual (0)
+
+          param.asAdmin(Post("/v0/hooks/test/ack", WebHookAcknowledgement(false, None, Some(true)))) ~> param.api.routes ~> check {
+            status shouldEqual StatusCodes.OK
+          }
+
+          Util.waitUntilDone(actor, "test")
+
+          payloads.length shouldEqual (1)
+
+          val aspectDefinition2 = AspectDefinition("testId2", "testName2", Some(JsObject()))
+          param.asAdmin(Post("/v0/aspects", aspectDefinition2)) ~> param.api.routes ~> check {
+            status shouldEqual StatusCodes.OK
+          }
+
+          param.asAdmin(Post("/v0/hooks/test/ack", WebHookAcknowledgement(true, Some(payloads.last.lastEventId)))) ~> param.api.routes ~> check {
+            status shouldEqual StatusCodes.OK
+          }
+
+          Util.waitUntilDone(actor, "test")
+
+          payloads.length shouldEqual (2)
+        }
       }
     }
   }

--- a/magda-registry-datastore/sql/V1_5__Tune_indices.sql
+++ b/magda-registry-datastore/sql/V1_5__Tune_indices.sql
@@ -1,0 +1,12 @@
+-- In the future this should be dynamic.
+CREATE INDEX reports_data_gin_idx
+    ON recordaspects USING gin
+    ((data -> 'distributions'::text));
+
+CREATE INDEX events_recordid_idx
+    ON events USING btree
+    ((data ->> 'recordId'::text));
+
+CREATE INDEX events_aspectid_idx
+    ON events USING btree
+    ((data ->> 'aspectId'::text));

--- a/magda-scala-common/src/main/scala/au/csiro/data61/magda/model/Registry.scala
+++ b/magda-scala-common/src/main/scala/au/csiro/data61/magda/model/Registry.scala
@@ -109,8 +109,10 @@ object Registry {
   @ApiModel(description = "Asynchronously acknowledges receipt of a web hook notification.")
   case class WebHookAcknowledgement(
     @(ApiModelProperty @field)(value = "True if the web hook was received successfully and the listener is ready for further notifications.  False if the web hook was not received and the same notification should be repeated.", required = true) succeeded: Boolean,
-
-    @(ApiModelProperty @field)(value = "The ID of the last event received by the listener.  This should be the value of the `lastEventId` property of the web hook payload that is being acknowledged.  This value is ignored if `succeeded` is false.", required = true) lastEventIdReceived: Option[Long] = None)
+    
+    @(ApiModelProperty @field)(value = "The ID of the last event received by the listener.  This should be the value of the `lastEventId` property of the web hook payload that is being acknowledged.  This value is ignored if `succeeded` is false.", required = true) lastEventIdReceived: Option[Long] = None,
+    
+    @(ApiModelProperty @field)(value = "Should the webhook be active or inactive?", required = false) active: Option[Boolean] = None)
 
   @ApiModel(description = "The response to an asynchronous web hook acknowledgement.")
   case class WebHookAcknowledgementResponse(
@@ -130,7 +132,7 @@ object Registry {
     implicit val webHookFormat = jsonFormat9(WebHook.apply)
     implicit val registryRecordsResponseFormat = jsonFormat3(RegistryRecordsResponse.apply)
     implicit def qualityRatingAspectFormat = jsonFormat2(QualityRatingAspect.apply)
-    implicit val webHookAcknowledgementFormat = jsonFormat2(WebHookAcknowledgement.apply)
+    implicit val webHookAcknowledgementFormat = jsonFormat3(WebHookAcknowledgement.apply)
     implicit val webHookAcknowledgementResponse = jsonFormat1(WebHookAcknowledgementResponse.apply)
   }
 

--- a/magda-sleuther-broken-link/src/onRecordFound.ts
+++ b/magda-sleuther-broken-link/src/onRecordFound.ts
@@ -194,7 +194,23 @@ function checkDistributionLink(
     }
 
     return urls.map(url => {
-        const parsedURL = new URI(url.url);
+        let parsedURL: uri.URI;
+        try {
+            parsedURL = new URI(url.url);
+        } catch (err) {
+            return {
+                host: "unknown",
+                op: () =>
+                    Promise.resolve({
+                        distribution,
+                        urlType: url.type,
+                        aspect: {
+                            status: "broken" as RetrieveResult,
+                            errorDetails: err
+                        }
+                    })
+            };
+        }
         return {
             host: (parsedURL && parsedURL.host()) as string,
             op: () => {

--- a/magda-sleuther-broken-link/src/parseUriSafe.ts
+++ b/magda-sleuther-broken-link/src/parseUriSafe.ts
@@ -1,0 +1,9 @@
+import * as URI from "urijs";
+
+export default function parseUriSafe(url: string): uri.URI | undefined {
+    try {
+        return new URI(url);
+    } catch (e) {
+        return undefined;
+    }
+}

--- a/magda-sleuther-broken-link/src/test/onRecordFound.spec.ts
+++ b/magda-sleuther-broken-link/src/test/onRecordFound.spec.ts
@@ -29,6 +29,7 @@ import {
 } from "./arbitraries";
 import FtpHandler from "../FtpHandler";
 import AuthorizedRegistryClient from "@magda/typescript-common/dist/registry/AuthorizedRegistryClient";
+import parseUriSafe from "../parseUriSafe";
 
 describe("onRecordFound", function(this: Mocha.ISuiteCallbackContext) {
     this.timeout(20000);
@@ -72,9 +73,9 @@ describe("onRecordFound", function(this: Mocha.ISuiteCallbackContext) {
     };
 
     /**
-   * Builds FTP clients that have all their important methods stubbed out - these
-   * will respond based on the current content of ftpSuccesses.
-   */
+     * Builds FTP clients that have all their important methods stubbed out - these
+     * will respond based on the current content of ftpSuccesses.
+     */
     const clientFactory = () => {
         const client = new Client();
         let readyCallback: () => void;
@@ -130,32 +131,32 @@ describe("onRecordFound", function(this: Mocha.ISuiteCallbackContext) {
     const fakeFtpHandler = new FtpHandler(clientFactory);
 
     /**
-   * Generator-driven super-test: generates records and runs them through the
-   * onRecordFound function, listening for HTTP and FTP calls made and returning
-   * success or failure based on generated outcomes, then checks that they're
-   * recorded on a by-distribution basis as link status as well as on a by-record
-   * basis as a part of dataset quality.
-   */
+     * Generator-driven super-test: generates records and runs them through the
+     * onRecordFound function, listening for HTTP and FTP calls made and returning
+     * success or failure based on generated outcomes, then checks that they're
+     * recorded on a by-distribution basis as link status as well as on a by-record
+     * basis as a part of dataset quality.
+     */
     it("Should correctly record link statuses and quality", function() {
         return jsc.assert(
-            jsc.forall(recordArbWithSuccesses, ({ record, successes }) => {
+            jsc.forall(recordArbWithSuccesses, ({ record, successLookup }) => {
                 beforeEachProperty();
 
                 // Tell the FTP server to return success/failure for the various FTP
                 // paths with this dodgy method. Note that because the FTP server can
                 // only see paths and not host, we only send it the path of the req.
-                ftpSuccesses = _.pickBy(successes, (value, url) =>
-                    url.startsWith("ftp")
+                ftpSuccesses = _.pickBy(successLookup, (value, url) =>
+                    hasProtocol(url, "ftp")
                 );
 
                 const allDists =
                     record.aspects["dataset-distributions"].distributions;
 
                 const httpDistUrls = _(urlsFromDataSet(record))
-                    .filter((x: string) => x.startsWith("http"))
+                    .filter((url: string) => hasProtocol(url, "http"))
                     .map((url: string) => ({
                         url,
-                        success: successes[url]
+                        success: successLookup[url]
                     }))
                     .value();
 
@@ -188,17 +189,19 @@ describe("onRecordFound", function(this: Mocha.ISuiteCallbackContext) {
                         "dcat-distribution-strings"
                     ];
                     const success =
-                        successes[downloadURL] === "success"
+                        successLookup[downloadURL] === "success"
                             ? "success"
-                            : successes[accessURL];
+                            : successLookup[accessURL];
 
                     const isUnknownProtocol = (url: string) => {
                         if (!url) {
                             return false;
                         }
-                        const scheme = URI(url).scheme();
+                        const protocol = new URI(url).protocol();
                         return (
-                            !scheme || KNOWN_PROTOCOLS.indexOf(scheme) === -1
+                            protocol &&
+                            protocol.length > 0 &&
+                            KNOWN_PROTOCOLS.indexOf(protocol) === -1
                         );
                     };
 
@@ -220,37 +223,47 @@ describe("onRecordFound", function(this: Mocha.ISuiteCallbackContext) {
                             (body: BrokenLinkAspect) => {
                                 const doesStatusMatch = body.status === result;
 
-                                const isDownloadUrlHttp =
-                                    downloadURL &&
-                                    downloadURL.startsWith("http");
-                                const isAccessUrlHttp =
-                                    accessURL && accessURL.startsWith("http");
+                                const isDownloadUrlHttp = hasProtocol(
+                                    downloadURL,
+                                    "http"
+                                );
+                                const isAccessUrlHttp = hasProtocol(
+                                    accessURL,
+                                    "http"
+                                );
 
                                 const isDownloadUrlHttpSuccess =
                                     isDownloadUrlHttp &&
-                                    successes[downloadURL] === "success";
+                                    successLookup[downloadURL] === "success";
 
                                 const isDownloadUrlFtpSuccess =
                                     !isDownloadUrlHttp &&
-                                    successes[downloadURL] === "success";
+                                    successLookup[downloadURL] === "success";
 
                                 const isAccessURLHttpSuccess =
                                     isAccessUrlHttp &&
-                                    successes[accessURL] === "success";
+                                    successLookup[accessURL] === "success";
 
                                 const isHttpSuccess: boolean =
                                     isDownloadUrlHttpSuccess ||
                                     (!isDownloadUrlFtpSuccess &&
                                         isAccessURLHttpSuccess);
 
+                                const downloadUri = parseUriSafe(downloadURL);
+                                const isDownloadUrlDefined =
+                                    _.isUndefined(downloadUri) ||
+                                    !downloadUri.scheme() ||
+                                    parseUriSafe(downloadURL).scheme()
+                                        .length === 0;
+
                                 const is404: boolean =
                                     result === "broken" &&
                                     ((isDownloadUrlHttp &&
-                                        successes[downloadURL] ===
+                                        successLookup[downloadURL] ===
                                             "notfound") ||
-                                        (_.isUndefined(downloadURL) &&
+                                        (isDownloadUrlDefined &&
                                             isAccessUrlHttp &&
-                                            successes[accessURL] ===
+                                            successLookup[accessURL] ===
                                                 "notfound"));
 
                                 const doesResponseCodeMatch = ((
@@ -273,7 +286,9 @@ describe("onRecordFound", function(this: Mocha.ISuiteCallbackContext) {
                                 );
 
                                 // console.log(
-                                //   `${dist.id}: ${doesStatusMatch} && ${doesResponseCodeMatch} && ${doesErrorMatch} `
+                                //     `${
+                                //         dist.id
+                                //     }: ${doesStatusMatch} && ${doesResponseCodeMatch} && ${doesErrorMatch} `
                                 // );
 
                                 return (
@@ -334,20 +349,20 @@ describe("onRecordFound", function(this: Mocha.ISuiteCallbackContext) {
 
     describe("retrying", () => {
         /**
-     * Runs onRecordFound with a number of failing codes, testing whether the
-     * sleuther retries the correct number of times, and whether it correctly
-     * records a success after retries or a failure after the retries run out.
-     *
-     * This tests both 429 retries and other retries - this involves different
-     * behaviour as the retry for 429 (which indicates rate limiting) require
-     * a much longer cool-off time and hence are done differently.
-     *
-     * @param caption The caption to use for the mocha "it" call.
-     * @param result Whether to test for a number of retries then a success, a
-     *                number of retries then a failure because of too many 429s,
-     *                or a number of retries then a failure because of too many
-     *                non-429 failures (e.g. 404s)
-     */
+         * Runs onRecordFound with a number of failing codes, testing whether the
+         * sleuther retries the correct number of times, and whether it correctly
+         * records a success after retries or a failure after the retries run out.
+         *
+         * This tests both 429 retries and other retries - this involves different
+         * behaviour as the retry for 429 (which indicates rate limiting) require
+         * a much longer cool-off time and hence are done differently.
+         *
+         * @param caption The caption to use for the mocha "it" call.
+         * @param result Whether to test for a number of retries then a success, a
+         *                number of retries then a failure because of too many 429s,
+         *                or a number of retries then a failure because of too many
+         *                non-429 failures (e.g. 404s)
+         */
         const retrySpec = (
             caption: string,
             result: "success" | "fail429" | "failNormal"
@@ -361,11 +376,11 @@ describe("onRecordFound", function(this: Mocha.ISuiteCallbackContext) {
                 };
 
                 /**
-         * Generates a retryCount and a nested array of results to return to the
-         * sleuther - the inner arrays are status codes to be returned (in order),
-         * after each inner array is finished a 429 will be returned, then the
-         * next array of error codes will be returned.
-         */
+                 * Generates a retryCount and a nested array of results to return to the
+                 * sleuther - the inner arrays are status codes to be returned (in order),
+                 * after each inner array is finished a 429 will be returned, then the
+                 * next array of error codes will be returned.
+                 */
                 const failuresArb: jsc.Arbitrary<
                     FailuresArbResult
                 > = arbFlatMap<number, FailuresArbResult>(
@@ -432,35 +447,39 @@ describe("onRecordFound", function(this: Mocha.ISuiteCallbackContext) {
                         ) => {
                             beforeEachProperty();
 
-                            const distScopes = urlsFromDataSet(
-                                record
-                            ).map(url => {
-                                const scope = nock(url); //.log(console.log);
+                            const distScopes = urlsFromDataSet(record).map(
+                                url => {
+                                    const scope = nock(url); //.log(console.log);
 
-                                allResults.forEach((failureCodes, i) => {
-                                    failureCodes.forEach(failureCode => {
-                                        scope
-                                            .head(url.endsWith("/") ? "/" : "")
-                                            .reply(failureCode);
+                                    allResults.forEach((failureCodes, i) => {
+                                        failureCodes.forEach(failureCode => {
+                                            scope
+                                                .head(
+                                                    url.endsWith("/") ? "/" : ""
+                                                )
+                                                .reply(failureCode);
+                                        });
+                                        if (
+                                            i < allResults.length - 1 ||
+                                            result === "fail429"
+                                        ) {
+                                            scope
+                                                .head(
+                                                    url.endsWith("/") ? "/" : ""
+                                                )
+                                                .reply(429);
+                                        }
                                     });
-                                    if (
-                                        i < allResults.length - 1 ||
-                                        result === "fail429"
-                                    ) {
+
+                                    if (result === "success") {
                                         scope
                                             .head(url.endsWith("/") ? "/" : "")
-                                            .reply(429);
+                                            .reply(200);
                                     }
-                                });
 
-                                if (result === "success") {
-                                    scope
-                                        .head(url.endsWith("/") ? "/" : "")
-                                        .reply(200);
+                                    return scope;
                                 }
-
-                                return scope;
-                            });
+                            );
 
                             const allDists =
                                 record.aspects["dataset-distributions"]
@@ -689,3 +708,9 @@ describe("onRecordFound", function(this: Mocha.ISuiteCallbackContext) {
         }
     );
 });
+
+function hasProtocol(url: string, protocol: string) {
+    const uri = parseUriSafe(url);
+
+    return uri && uri.protocol().startsWith(protocol);
+}

--- a/magda-sleuther-framework/src/setupWebhookEndpoint.ts
+++ b/magda-sleuther-framework/src/setupWebhookEndpoint.ts
@@ -88,11 +88,13 @@ export default function setupWebhookEndpoint(
                         // TODO: Figure out some way to notify of failures.
                         console.error(err);
 
-                        console.log("Setting hook to inactive");
-                        registry.putHook({
-                            id: options.id,
-                            active: false
-                        })
+                        console.info("Setting hook to inactive");
+                        return registry.resumeHook(
+                            options.id,
+                            false,
+                            payload.lastEventId,
+                            false
+                        );
                     });
             } else {
                 megaPromise

--- a/magda-sleuther-framework/src/setupWebhookEndpoint.ts
+++ b/magda-sleuther-framework/src/setupWebhookEndpoint.ts
@@ -7,7 +7,9 @@ import unionToThrowable from "@magda/typescript-common/dist/util/unionToThrowabl
 
 import SleutherOptions from "./SleutherOptions";
 import getWebhookUrl from "./getWebhookUrl";
-import AsyncPage, { forEachAsync } from "@magda/typescript-common/dist/AsyncPage";
+import AsyncPage, {
+    forEachAsync
+} from "@magda/typescript-common/dist/AsyncPage";
 
 export default function setupWebhookEndpoint(
     options: SleutherOptions,
@@ -20,7 +22,7 @@ export default function setupWebhookEndpoint(
         "/hook",
         (request: express.Request, response: express.Response) => {
             const payload = request.body;
-            
+
             const recordsPage = AsyncPage.single(payload.records);
             const megaPromise = forEachAsync(
                 recordsPage,
@@ -72,10 +74,17 @@ export default function setupWebhookEndpoint(
                             throw error;
                         });
 
-                megaPromise.then(() => sendResult(true)).catch((err: Error) => {
-                    console.error(err);
-                    return sendResult(false);
-                });
+                megaPromise
+                    .catch((err: Error) => {
+                        // Not much we can really do about this except log it and keep going.
+                        // TODO: Figure out some way to notify of failures.
+                        console.error(err);
+                    })
+                    .then(() => sendResult(true))
+                    .catch((err: Error) => {
+                        console.error(err);
+                        return sendResult(false);
+                    });
             } else {
                 megaPromise
                     .then(() => {

--- a/magda-sleuther-framework/src/test/webhooks.spec.ts
+++ b/magda-sleuther-framework/src/test/webhooks.spec.ts
@@ -165,8 +165,10 @@ baseSpec(
                                                             options.id
                                                         }/ack`,
                                                         {
-                                                            succeeded:
-                                                                batch.overallSuccess,
+                                                            // We post succeeded: true even if we failed because in the event of
+                                                            // an uncaught error from the sleuther we want to move on, not get
+                                                            // stuck in a loop. "succeeded" would be better called "repeatWebhook"
+                                                            succeeded: true,
                                                             lastEventIdReceived: lastHookId
                                                         }
                                                     )

--- a/magda-sleuther-framework/src/test/webhooks.spec.ts
+++ b/magda-sleuther-framework/src/test/webhooks.spec.ts
@@ -169,9 +169,11 @@ baseSpec(
                                                                 batch.overallSuccess,
                                                             lastEventIdReceived: lastHookId,
                                                             // Deactivate if not successful.
-                                                            active: !batch.overallSuccess
-                                                                ? false
-                                                                : undefined
+                                                            ...(batch.overallSuccess
+                                                                ? {}
+                                                                : {
+                                                                      active: false
+                                                                  })
                                                         }
                                                     )
                                                     .reply(201);

--- a/magda-sleuther-framework/src/test/webhooks.spec.ts
+++ b/magda-sleuther-framework/src/test/webhooks.spec.ts
@@ -165,11 +165,13 @@ baseSpec(
                                                             options.id
                                                         }/ack`,
                                                         {
-                                                            // We post succeeded: true even if we failed because in the event of
-                                                            // an uncaught error from the sleuther we want to move on, not get
-                                                            // stuck in a loop. "succeeded" would be better called "repeatWebhook"
-                                                            succeeded: true,
-                                                            lastEventIdReceived: lastHookId
+                                                            succeeded:
+                                                                batch.overallSuccess,
+                                                            lastEventIdReceived: lastHookId,
+                                                            // Deactivate if not successful.
+                                                            active: !batch.overallSuccess
+                                                                ? false
+                                                                : undefined
                                                         }
                                                     )
                                                     .reply(201);

--- a/magda-typescript-common/src/generated/registry/api.ts
+++ b/magda-typescript-common/src/generated/registry/api.ts
@@ -67,10 +67,6 @@ export type EventType =
 */
 export class EventsPage {
     /**
-    * The total number of events available.
-    */
-    'totalCount': number;
-    /**
     * A token to be used to get the next page of events.
     */
     'nextPageToken': string;

--- a/magda-typescript-common/src/generated/registry/api.ts
+++ b/magda-typescript-common/src/generated/registry/api.ts
@@ -154,6 +154,10 @@ export class WebHookAcknowledgement {
     * The ID of the last event received by the listener.  This should be the value of the `lastEventId` property of the web hook payload that is being acknowledged.  This value is ignored if `succeeded` is false.
     */
     'lastEventIdReceived': any;
+    /**
+    * Should the webhook be active or inactive?
+    */
+    'active': any;
 }
 
 /**

--- a/magda-typescript-common/src/registry/AuthorizedRegistryClient.ts
+++ b/magda-typescript-common/src/registry/AuthorizedRegistryClient.ts
@@ -153,12 +153,13 @@ export default class AuthorizedRegistryClient extends RegistryClient {
     resumeHook(
         webhookId: string,
         succeeded: boolean = false,
-        lastEventIdReceived: string = null
+        lastEventIdReceived: string = null,
+        active?: boolean
     ): Promise<WebHookAcknowledgementResponse | Error> {
         const operation = () =>
             this.webHooksApi.ack(
                 encodeURIComponent(webhookId),
-                { succeeded, lastEventIdReceived },
+                { succeeded, lastEventIdReceived, active },
                 this.jwt
             );
 


### PR DESCRIPTION
Fixes #370 

### What this PR does
- Optimises the query used for getting new events for each webhook
- Stops the sleuther framework posting `success: false` as the result of an uncaught error - this has the effect of just replaying that set of events over and over so they generally fail, over and over.
- Makes the broken link sleuther handle nonsense URLs like "active" better.

### Checklist
- [x] There are unit tests to verify my changes are correct (or unit tests aren't applicable)
- [x] I've updated CHANGES.md with what I changed.
