### PR TITLE
284 filter records by aspect contents

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,3 +10,4 @@
 * Optimised the query that finds new events for each webhook
 * Stopped async webhooks posting `success: false` on an uncaught failure, as this just causes them to process the same data and fail over and over.
 * Stopped the broken link sleuther from failing completely when it gets a string that isn't a valid URL - now records as "broken".
+* Added ability to get records from the registry by the value of their aspects.

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/AspectQuery.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/AspectQuery.scala
@@ -1,0 +1,24 @@
+package au.csiro.data61.magda.registry
+
+import java.net.URLDecoder
+case class AspectQuery(
+  aspectId: String,
+  path: List[String],
+  value: String)
+
+object AspectQuery {
+  def parse(string: String): AspectQuery = {
+    val Array(path, value) = string.split(":").map(URLDecoder.decode(_, "utf-8"))
+    val pathParts = path.split("\\.").toList
+
+    if (value.isEmpty) {
+      throw new Exception("Value for aspect query is not present.")
+    }
+
+    if (pathParts.length < 2) {
+      throw new Exception("Path for aspect query was empty")
+    }
+
+    AspectQuery(pathParts.head, pathParts.tail, value)
+  }
+}

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordPersistence.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordPersistence.scala
@@ -29,13 +29,13 @@ object RecordPersistence extends Protocols with DiffsonProtocol {
                         start: Option[Int] = None,
                         limit: Option[Int] = None,
                         dereference: Option[Boolean] = None,
-                        aspectQuery: Option[AspectQuery] = None): RecordsPage[Record] = {
-    val selector = aspectQuery.map { query =>
+                        aspectQueries: Iterable[AspectQuery] = Nil): RecordsPage[Record] = {
+    val selectors = aspectQueries.map { query =>
       val path = query.path.map(pathElement => sqls"->>$pathElement").reduce((a, b) => a.append(b))
       sqls"EXISTS (SELECT 1 FROM recordaspects WHERE recordaspects.recordid=records.recordid AND aspectId = ${query.aspectId} AND data #>> ${"{" + query.path.mkString(",") + "}"}::varchar[] = ${query.value})"
-    }
+    } map (Some.apply)
 
-    this.getRecords(session, aspectIds, optionalAspectIds, pageToken, start, limit, dereference, List(selector))
+    this.getRecords(session, aspectIds, optionalAspectIds, pageToken, start, limit, dereference, selectors)
   }
 
   def getById(implicit session: DBSession, id: String): Option[RecordSummary] = {

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordsService.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordsService.scala
@@ -35,11 +35,13 @@ class RecordsService(config: Config, webHookActor: ActorRef, authClient: AuthApi
     new ApiImplicitParam(name = "dereference", required = false, dataType = "boolean", paramType = "query", value = "true to automatically dereference links to other records; false to leave them as links.  Dereferencing a link means including the record itself where the link would be.  Dereferencing only happens one level deep, regardless of the value of this parameter.")))
   def getAll = get {
     pathEnd {
-      parameters('aspect.*, 'optionalAspect.*, 'pageToken.?, 'start.as[Int].?, 'limit.as[Int].?, 'dereference.as[Boolean].?) {
-        (aspects, optionalAspects, pageToken, start, limit, dereference) =>
+      parameters('aspect.*, 'optionalAspect.*, 'pageToken.?, 'start.as[Int].?, 'limit.as[Int].?, 'dereference.as[Boolean].?, 'aspectQuery.?) {
+        (aspects, optionalAspects, pageToken, start, limit, dereference, aspectQuery) =>
+          val parsedAspectQuery = aspectQuery.map(AspectQuery.parse)
+          
           complete {
             DB readOnly { session =>
-              RecordPersistence.getAllWithAspects(session, aspects, optionalAspects, pageToken, start, limit, dereference)
+              RecordPersistence.getAllWithAspects(session, aspects, optionalAspects, pageToken, start, limit, dereference, parsedAspectQuery)
             }
           }
       }

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordsService.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordsService.scala
@@ -35,13 +35,13 @@ class RecordsService(config: Config, webHookActor: ActorRef, authClient: AuthApi
     new ApiImplicitParam(name = "dereference", required = false, dataType = "boolean", paramType = "query", value = "true to automatically dereference links to other records; false to leave them as links.  Dereferencing a link means including the record itself where the link would be.  Dereferencing only happens one level deep, regardless of the value of this parameter.")))
   def getAll = get {
     pathEnd {
-      parameters('aspect.*, 'optionalAspect.*, 'pageToken.?, 'start.as[Int].?, 'limit.as[Int].?, 'dereference.as[Boolean].?, 'aspectQuery.?) {
-        (aspects, optionalAspects, pageToken, start, limit, dereference, aspectQuery) =>
-          val parsedAspectQuery = aspectQuery.map(AspectQuery.parse)
+      parameters('aspect.*, 'optionalAspect.*, 'pageToken.?, 'start.as[Int].?, 'limit.as[Int].?, 'dereference.as[Boolean].?, 'aspectQuery.*) {
+        (aspects, optionalAspects, pageToken, start, limit, dereference, aspectQueries) =>
+          val parsedAspectQueries = aspectQueries.map(AspectQuery.parse)
           
           complete {
             DB readOnly { session =>
-              RecordPersistence.getAllWithAspects(session, aspects, optionalAspects, pageToken, start, limit, dereference, parsedAspectQuery)
+              RecordPersistence.getAllWithAspects(session, aspects, optionalAspects, pageToken, start, limit, dereference, parsedAspectQueries)
             }
           }
       }

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordsService.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordsService.scala
@@ -32,13 +32,14 @@ class RecordsService(config: Config, webHookActor: ActorRef, authClient: AuthApi
     new ApiImplicitParam(name = "pageToken", required = false, dataType = "string", paramType = "query", value = "A token that identifies the start of a page of results.  This token should not be interpreted as having any meaning, but it can be obtained from a previous page of results."),
     new ApiImplicitParam(name = "start", required = false, dataType = "number", paramType = "query", value = "The index of the first record to retrieve.  When possible, specify pageToken instead as it will result in better performance.  If this parameter and pageToken are both specified, this parameter is interpreted as the index after the pageToken of the first record to retrieve."),
     new ApiImplicitParam(name = "limit", required = false, dataType = "number", paramType = "query", value = "The maximum number of records to receive.  The response will include a token that can be passed as the pageToken parameter to a future request to continue receiving results where this query leaves off."),
-    new ApiImplicitParam(name = "dereference", required = false, dataType = "boolean", paramType = "query", value = "true to automatically dereference links to other records; false to leave them as links.  Dereferencing a link means including the record itself where the link would be.  Dereferencing only happens one level deep, regardless of the value of this parameter.")))
+    new ApiImplicitParam(name = "dereference", required = false, dataType = "boolean", paramType = "query", value = "true to automatically dereference links to other records; false to leave them as links.  Dereferencing a link means including the record itself where the link would be.  Dereferencing only happens one level deep, regardless of the value of this parameter."),
+    new ApiImplicitParam(name = "aspectQuery", required = false, dataType = "string", paramType = "query", allowMultiple = true, value = "Filter the records returned by a value within the aspect JSON. Expressed as 'aspectId.path.to.field:value', url encoded. NOTE: This is an early stage API and may change greatly in the future")))
   def getAll = get {
     pathEnd {
       parameters('aspect.*, 'optionalAspect.*, 'pageToken.?, 'start.as[Int].?, 'limit.as[Int].?, 'dereference.as[Boolean].?, 'aspectQuery.*) {
         (aspects, optionalAspects, pageToken, start, limit, dereference, aspectQueries) =>
           val parsedAspectQueries = aspectQueries.map(AspectQuery.parse)
-          
+
           complete {
             DB readOnly { session =>
               RecordPersistence.getAllWithAspects(session, aspects, optionalAspects, pageToken, start, limit, dereference, parsedAspectQueries)

--- a/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/RecordsServiceSpec.scala
+++ b/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/RecordsServiceSpec.scala
@@ -309,35 +309,6 @@ class RecordsServiceSpec extends ApiSpec {
         }
       }
 
-      it("allows querying on aspect value") { param =>
-        val aspect = AspectDefinition("exampleAspect", "exampleAspect", None)
-        param.asAdmin(Post("/v0/aspects", aspect)) ~> param.api.routes ~> check {
-          status shouldEqual StatusCodes.OK
-        }
-
-        val recordWithValue1 = Record("withValue1", "withValue1", Map("exampleAspect" -> JsObject("object" -> JsObject("value" -> JsString("correct")))))
-        param.asAdmin(Post("/v0/records", recordWithValue1)) ~> param.api.routes ~> check {
-          status shouldEqual StatusCodes.OK
-        }
-
-        val recordWithValue2 = Record("withValue2", "withValue2", Map("exampleAspect" -> JsObject("object" -> JsObject("value" -> JsString("correct")))))
-        param.asAdmin(Post("/v0/records", recordWithValue2)) ~> param.api.routes ~> check {
-          status shouldEqual StatusCodes.OK
-        }
-
-        val recordWithoutValue = Record("withoutValue", "withoutValue", Map("exampleAspect" -> JsObject("object" -> JsObject("value" -> JsString("incorrect")))))
-        param.asAdmin(Post("/v0/records", recordWithoutValue)) ~> param.api.routes ~> check {
-          status shouldEqual StatusCodes.OK
-        }
-
-        Get("/v0/records?aspectQuery=exampleAspect.object.value:correct") ~> param.api.routes ~> check {
-          status shouldEqual StatusCodes.OK
-          val page = responseAs[RecordsPage[Record]]
-          page.records.length shouldBe 2
-          page.records(0) shouldBe recordWithValue1
-          page.records(1) shouldBe recordWithValue2
-        }
-      }
     }
 
     describe("dereference") {
@@ -474,6 +445,128 @@ class RecordsServiceSpec extends ApiSpec {
                 "aspects" -> JsObject(
                   "withLinks" -> JsObject(
                     "someLinks" -> JsArray(JsString("source")))))))
+        }
+      }
+    }
+
+    describe("querying by aspect value") {
+      it("works for shallow paths") { param =>
+        val aspect = AspectDefinition("exampleAspect", "exampleAspect", None)
+        param.asAdmin(Post("/v0/aspects", aspect)) ~> param.api.routes ~> check {
+          status shouldEqual StatusCodes.OK
+        }
+
+        val recordWithValue1 = Record("withValue1", "withValue1", Map("exampleAspect" -> JsObject("value" -> JsString("correct"))))
+        param.asAdmin(Post("/v0/records", recordWithValue1)) ~> param.api.routes ~> check {
+          status shouldEqual StatusCodes.OK
+        }
+
+        val recordWithValue2 = Record("withValue2", "withValue2", Map("exampleAspect" -> JsObject("value" -> JsString("correct"))))
+        param.asAdmin(Post("/v0/records", recordWithValue2)) ~> param.api.routes ~> check {
+          status shouldEqual StatusCodes.OK
+        }
+
+        val recordWithoutValue = Record("withoutValue", "withoutValue", Map("exampleAspect" -> JsObject("value" -> JsString("incorrect"))))
+        param.asAdmin(Post("/v0/records", recordWithoutValue)) ~> param.api.routes ~> check {
+          status shouldEqual StatusCodes.OK
+        }
+
+        Get("/v0/records?aspectQuery=exampleAspect.value:correct&aspect=exampleAspect") ~> param.api.routes ~> check {
+          status shouldEqual StatusCodes.OK
+          val page = responseAs[RecordsPage[Record]]
+          page.records.length shouldBe 2
+          page.records(0) shouldBe recordWithValue1
+          page.records(1) shouldBe recordWithValue2
+        }
+      }
+
+      it("works without specifying the aspect in aspects or optionalAspects") { param =>
+        val aspect = AspectDefinition("exampleAspect", "exampleAspect", None)
+        param.asAdmin(Post("/v0/aspects", aspect)) ~> param.api.routes ~> check {
+          status shouldEqual StatusCodes.OK
+        }
+
+        val recordWithValue1 = Record("withValue1", "withValue1", Map("exampleAspect" -> JsObject("value" -> JsString("correct"))))
+        param.asAdmin(Post("/v0/records", recordWithValue1)) ~> param.api.routes ~> check {
+          status shouldEqual StatusCodes.OK
+        }
+
+        val recordWithValue2 = Record("withValue2", "withValue2", Map("exampleAspect" -> JsObject("value" -> JsString("correct"))))
+        param.asAdmin(Post("/v0/records", recordWithValue2)) ~> param.api.routes ~> check {
+          status shouldEqual StatusCodes.OK
+        }
+
+        val recordWithoutValue = Record("withoutValue", "withoutValue", Map("exampleAspect" -> JsObject("value" -> JsString("incorrect"))))
+        param.asAdmin(Post("/v0/records", recordWithoutValue)) ~> param.api.routes ~> check {
+          status shouldEqual StatusCodes.OK
+        }
+
+        Get("/v0/records?aspectQuery=exampleAspect.value:correct") ~> param.api.routes ~> check {
+          status shouldEqual StatusCodes.OK
+          val page = responseAs[RecordsPage[Record]]
+          page.records.length shouldBe 2
+          page.records(0).id shouldBe "withValue1"
+          page.records(1).id shouldBe "withValue2"
+        }
+      }
+
+      it("works for deep paths") { param =>
+        val aspect = AspectDefinition("exampleAspect", "exampleAspect", None)
+        param.asAdmin(Post("/v0/aspects", aspect)) ~> param.api.routes ~> check {
+          status shouldEqual StatusCodes.OK
+        }
+
+        val recordWithValue1 = Record("withValue1", "withValue1", Map("exampleAspect" -> JsObject("object" -> JsObject("value" -> JsString("correct")))))
+        param.asAdmin(Post("/v0/records", recordWithValue1)) ~> param.api.routes ~> check {
+          status shouldEqual StatusCodes.OK
+        }
+
+        val recordWithValue2 = Record("withValue2", "withValue2", Map("exampleAspect" -> JsObject("object" -> JsObject("value" -> JsString("correct")))))
+        param.asAdmin(Post("/v0/records", recordWithValue2)) ~> param.api.routes ~> check {
+          status shouldEqual StatusCodes.OK
+        }
+
+        val recordWithoutValue = Record("withoutValue", "withoutValue", Map("exampleAspect" -> JsObject("object" -> JsObject("value" -> JsString("incorrect")))))
+        param.asAdmin(Post("/v0/records", recordWithoutValue)) ~> param.api.routes ~> check {
+          status shouldEqual StatusCodes.OK
+        }
+
+        Get("/v0/records?aspectQuery=exampleAspect.object.value:correct&aspect=exampleAspect") ~> param.api.routes ~> check {
+          status shouldEqual StatusCodes.OK
+          val page = responseAs[RecordsPage[Record]]
+          page.records.length shouldBe 2
+          page.records(0) shouldBe recordWithValue1
+          page.records(1) shouldBe recordWithValue2
+        }
+      }
+
+      it("works as AND when multiple queries specified") { param =>
+        val aspect = AspectDefinition("exampleAspect", "exampleAspect", None)
+        param.asAdmin(Post("/v0/aspects", aspect)) ~> param.api.routes ~> check {
+          status shouldEqual StatusCodes.OK
+        }
+
+        val recordWithValue1 = Record("withValue1", "withValue1", Map("exampleAspect" -> JsObject("value" -> JsString("correct"), "otherValue" -> JsString("alsoCorrect"))))
+        param.asAdmin(Post("/v0/records", recordWithValue1)) ~> param.api.routes ~> check {
+          status shouldEqual StatusCodes.OK
+        }
+
+        val recordWithValue2 = Record("withValue2", "withValue2", Map("exampleAspect" -> JsObject("value" -> JsString("correct"), "otherValue" -> JsString("alsoCorrect"))))
+        param.asAdmin(Post("/v0/records", recordWithValue2)) ~> param.api.routes ~> check {
+          status shouldEqual StatusCodes.OK
+        }
+
+        val recordWithoutValue = Record("withoutValue", "withoutValue", Map("exampleAspect" -> JsObject("value" -> JsString("correct"))))
+        param.asAdmin(Post("/v0/records", recordWithoutValue)) ~> param.api.routes ~> check {
+          status shouldEqual StatusCodes.OK
+        }
+
+        Get("/v0/records?aspectQuery=exampleAspect.value:correct&aspectQuery=exampleAspect.otherValue:alsoCorrect&aspect=exampleAspect") ~> param.api.routes ~> check {
+          status shouldEqual StatusCodes.OK
+          val page = responseAs[RecordsPage[Record]]
+          page.records.length shouldBe 2
+          page.records(0) shouldBe recordWithValue1
+          page.records(1) shouldBe recordWithValue2
         }
       }
     }

--- a/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/RecordsServiceSpec.scala
+++ b/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/RecordsServiceSpec.scala
@@ -330,9 +330,9 @@ class RecordsServiceSpec extends ApiSpec {
           status shouldEqual StatusCodes.OK
         }
 
-        Get("/v0/records?aspectQuery=object.value:correct&aspect=exampleAspect") ~> param.api.routes ~> check {
+        Get("/v0/records?aspectQuery=exampleAspect.object.value:correct") ~> param.api.routes ~> check {
           status shouldEqual StatusCodes.OK
-          val page = responseAs[RecordsPage]
+          val page = responseAs[RecordsPage[Record]]
           page.records.length shouldBe 2
           page.records(0) shouldBe recordWithValue1
           page.records(1) shouldBe recordWithValue2

--- a/magda-typescript-common/src/generated/registry/api.ts
+++ b/magda-typescript-common/src/generated/registry/api.ts
@@ -1226,8 +1226,9 @@ export class RecordsApi {
      * @param start The index of the first record to retrieve.  When possible, specify pageToken instead as it will result in better performance.  If this parameter and pageToken are both specified, this parameter is interpreted as the index after the pageToken of the first record to retrieve.
      * @param limit The maximum number of records to receive.  The response will include a token that can be passed as the pageToken parameter to a future request to continue receiving results where this query leaves off.
      * @param dereference true to automatically dereference links to other records; false to leave them as links.  Dereferencing a link means including the record itself where the link would be.  Dereferencing only happens one level deep, regardless of the value of this parameter.
+     * @param aspectQuery Filter the records returned by a value within the aspect JSON. Expressed as &#39;aspectId.path.to.field:value&#39;, url encoded. NOTE: This is an early stage API and may change greatly in the future
      */
-    public getAll (aspect?: Array<string>, optionalAspect?: Array<string>, pageToken?: string, start?: number, limit?: number, dereference?: boolean) : Promise<{ response: http.IncomingMessage; body: Array<Record>;  }> {
+    public getAll (aspect?: Array<string>, optionalAspect?: Array<string>, pageToken?: string, start?: number, limit?: number, dereference?: boolean, aspectQuery?: Array<string>) : Promise<{ response: http.IncomingMessage; body: Array<Record>;  }> {
         const localVarPath = this.basePath + '/records';
         let queryParameters: any = {};
         let headerParams: any = (<any>Object).assign({}, this.defaultHeaders);
@@ -1256,6 +1257,10 @@ export class RecordsApi {
 
         if (dereference !== undefined) {
             queryParameters['dereference'] = dereference;
+        }
+
+        if (aspectQuery !== undefined) {
+            queryParameters['aspectQuery'] = aspectQuery;
         }
 
         let useFormData = false;


### PR DESCRIPTION
Fixes #284 

### What this PR does
Introduces a _super-basic_ way to query for records based on their aspect contents. There's now an `aspectQuery` query param on `GET /records` in the registry, which you can pass a path and a value to in the format `aspectId.json.path:desiredValue` - this will URL decode and parse the query, then change it to a jsonb query in PostGres.

### Checklist
- [x] There are unit tests to verify my changes are correct (or unit tests aren't applicable)
- [x] I've updated CHANGES.md with what I changed.
