### PR TITLE
Fix Travis Build issue

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,3 +11,4 @@
 * Stopped async webhooks posting `success: false` on an uncaught failure, as this just causes them to process the same data and fail over and over.
 * Stopped the broken link sleuther from failing completely when it gets a string that isn't a valid URL - now records as "broken".
 * Added ability to get records from the registry by the value of their aspects.
+* Set `kubernetes-client` (required by magda-admin-api) version to `3.17.2` to sovle the travis build issue

--- a/magda-admin-api/package.json
+++ b/magda-admin-api/package.json
@@ -17,7 +17,7 @@
         "express": "^4.13.1",
         "http-proxy": "^1.16.2",
         "isomorphic-fetch": "^2.2.1",
-        "kubernetes-client": "^3.15.0",
+        "kubernetes-client": "3.17.2",
         "lodash": "^4.17.4",
         "util.promisify": "^1.0.0",
         "yargs": "^8.0.2"


### PR DESCRIPTION
### What this PR does

This PR solves recent travis build issue:
- Module `magda-admin-api` failed to build as incompatible version of `kubernetes-client`. The The issue was solved by fixing its version to `3.17.2`
- Module `magda-web-client` failed to build as recent release of `vega-canvas` introduced a [bug](https://github.com/vega/vega-canvas/blob/8acacccb82fd22460cf7b5c26e27b7c785ae5d0e/package.json#L38-L39) that will cause `webpack` fail to build.  The author has released a new version to fix this. Also, reset travis cache to eliminate issues on live travis system.

### Checklist
- [x] There are unit tests to verify my changes are correct (or unit tests aren't applicable)
- [x] I've updated CHANGES.md with what I changed.
