### PR TITLE
Issue 368/264: Direct access to urls `pages/*` will lead to `Cannot GET pages/*` error

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-## 0.0.32
+## 0.0.33
 
 * Connectors now create organizations, datasets, and distributions with IDs prefixed by the type of record and by the ID of the connector. For example, `org-bom-Australian Bureau of Meteorology` is the organization with the ID `Australian Bureau of Meteorology` from the connector with ID `bom`. Other type prefixes are `ds` for dataset and `dist` for distribution. This change avoids conflicting IDs from different sources.
 * Fixed a race condition in the registry that could lead to an error when multiple requests tried to create/update the same record simultaneously, which is fairly common when creating organizations in the CSW connector.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,3 +11,4 @@
 * Stopped async webhooks posting `success: false` on an uncaught failure, as this just causes them to process the same data and fail over and over.
 * Stopped the broken link sleuther from failing completely when it gets a string that isn't a valid URL - now records as "broken".
 * Added ability to get records from the registry by the value of their aspects.
+* Add route for `/pages/*` requests so that `magda-web-server` won't response `Cannot GET /page/*`

--- a/magda-web-server/src/index.ts
+++ b/magda-web-server/src/index.ts
@@ -167,6 +167,10 @@ topLevelRoutes.forEach(topLevelRoute => {
     });
 });
 
+app.get("/page/*", function(req, res) {
+    res.sendFile(path.join(clientBuild, "index.html"));
+});
+
 app.get("/admin", function(req, res) {
     res.sendFile(path.join(adminBuild, "index.html"));
 });


### PR DESCRIPTION
Fixes #368 #264 

### What this PR does

Fix issue that direct access to urls `pages/*` (e.g. http://search.data.gov.au/page/data-sources) will lead to `Cannot GET pages/*` error.

This issue may not be easy to replicate as:
1> Once user lands on home page, all content (including static pages) has been loaded via main js bundle. Any user clicks on static pages links (on screen) will not trigger HTTP requests.

2> Local Dev environment cannot replicate this issue as gateway will route all request to `http://localhost:6108` --- which is port of `magda-web-client` --- this will alway load index.html.
Production environment will router all requests to `http://web` --- which is the service name of `magda-web-server`. Thus, add route for `/pages/*` on `magda-web-server` will solve this issue.

### Checklist
- [x] There are unit tests to verify my changes are correct (or unit tests aren't applicable)
- [x] I've updated CHANGES.md with what I changed.
