### PR TITLE
Should add default `userId` to package.json of `magda-gateway` module

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,3 +19,4 @@
 * Added test cases for ApiClient class
 * Added test cased for Authorization APIs
 * Fixed minor frontend issue when Authorization APIs return non-json response
+* Add `userId` parameter to `package.json` of `magda-gateway` module

--- a/magda-gateway/package.json
+++ b/magda-gateway/package.json
@@ -61,6 +61,7 @@
       "include": "node_modules dist views Dockerfile"
     },
     "jwtSecret": "squirrel",
-    "SESSION_SECRET": "keyboard cat"
+    "SESSION_SECRET": "keyboard cat",
+    "userId": "00000000-0000-4000-8000-000000000000"
   }
 }


### PR DESCRIPTION
Fixes #385 

### What this PR does

The gateway is required to send default admin user Id to Auth API when access private API now.
And this parameter has not been set anywhere.
This commit will set this parameter in `package.json` like `madga-admin-api` module.

### Checklist
- [x] There are unit tests to verify my changes are correct (or unit tests aren't applicable)
- [x] I've updated CHANGES.md with what I changed.
