### PR TITLE
fix `magda-preview-map` hidden build issue: CSS not generated properly

### DIFF
--- a/magda-preview-map/package.json
+++ b/magda-preview-map/package.json
@@ -62,6 +62,7 @@
     "resolve-url-loader": "^2.0.2",
     "sass-loader": "^6.0.3",
     "semver": "^5.0.0",
+    "string-replace-webpack-plugin": "^0.1.3",
     "style-loader": "^0.19.1",
     "svg-baker": "^1.2.17",
     "svg-baker-runtime": "^1.3.3",


### PR DESCRIPTION
### What this PR does

fix `magda-preview-map` hidden build issue: CSS not generated properly

This issue was introduced by my merged [PR 458](https://github.com/TerriaJS/magda/pull/458) 


### Checklist
- [ ] There are unit tests to verify my changes are correct | Unit tests aren't applicable (delete one)
- [ ] I've updated CHANGES.md with what I changed.
- [ ] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column