### PR TITLE
Add feedback-api

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,7 @@
 * Merged latest changes (commits on or before 1st Feb 2018) from TerrisMap to `magda-preview-map` module
 * Map preview will zoom to dataset (except KML data)
 * Add Google Analytics Tag Manager Code / VWO code to `<head>`
+* Added `feedback-api` microservice to collect feedback and create GitHub issues from it.
 
 ## 0.0.32
 

--- a/deploy/helm/magda-dev.yml
+++ b/deploy/helm/magda-dev.yml
@@ -42,6 +42,8 @@ elasticsearch:
       limits:
         cpu: 1000m
         memory: 1500Mi
+feedback-api:
+  gitHubIssuesUrl: "https://api.github.com/repos/TerriaJS/Magda-Feedback/issues"
 indexer:
   resources:
     requests:

--- a/deploy/helm/magda/charts/feedback-api/Chart.yaml
+++ b/deploy/helm/magda/charts/feedback-api/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: A Helm chart for Kubernetes
+name: feedback-api
+version: 0.1.0

--- a/deploy/helm/magda/charts/feedback-api/templates/deployment.yaml
+++ b/deploy/helm/magda/charts/feedback-api/templates/deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: feedback-api
+spec:
+  strategy:
+    rollingUpdate:
+      maxUnavailable: {{ .Values.global.rollingUpdate.maxUnavailable | default 0 }}
+  template:
+    metadata:
+      labels:
+        service: feedback-api
+    spec:
+      containers:
+      - name: feedback-api
+        image: {{ template "dockerimage" . }}
+        imagePullPolicy: {{ .Values.image.pullPolicy | default .Values.global.image.pullPolicy }}
+        command: [
+            "node",
+            "/usr/src/app/component/dist/index.js",
+            "--listenPort", "80",
+{{- if .Values.gitHubIssuesUrl }}
+            "--issuesUrl", {{ .Values.gitHubIssuesUrl | quote }}
+{{- end }}
+        ]
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+        env:
+        - name: NODE_ENV
+          value: production
+{{- if .Values.gitHubIssuesUrl }}
+        - name: GITHUB_ACCESS_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: access-tokens
+              key: github-for-feedback
+              optional: true
+{{- end }}

--- a/deploy/helm/magda/charts/feedback-api/templates/service.yaml
+++ b/deploy/helm/magda/charts/feedback-api/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: feedback-api
+spec:
+  ports:
+  - name: http
+    port: 80
+    targetPort: 80
+{{- if .Values.global.exposeNodePorts }}
+    nodePort: 30116
+  type: NodePort
+{{- end }}
+  selector:
+    service: feedback-api

--- a/deploy/helm/magda/charts/feedback-api/values.yaml
+++ b/deploy/helm/magda/charts/feedback-api/values.yaml
@@ -1,0 +1,16 @@
+image: {}
+  #repository: data61/
+  #tag: latest
+  # pullPolicy: Always
+gitHubIssuesUrl:
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi

--- a/deploy/helm/magda/charts/gateway/templates/configmap.yaml
+++ b/deploy/helm/magda/charts/gateway/templates/configmap.yaml
@@ -26,5 +26,8 @@ data:
     "admin": {
         "to": "http://admin-api/v0",
         "auth": true
+    },
+    "feedback": {
+        "to": "http://feedback-api/v0"
     }
   }'

--- a/deploy/helm/magda/requirements.yaml
+++ b/deploy/helm/magda/requirements.yaml
@@ -35,6 +35,11 @@ dependencies:
     tags:
       - all
       - elasticsearch
+  - name: feedback-api
+    version: 0.1.0
+    tags:
+      - all
+      - feedback-api
   - name: gateway
     version: 0.1.0
     tags:

--- a/deploy/helm/magda/values.yaml
+++ b/deploy/helm/magda/values.yaml
@@ -19,6 +19,7 @@ tags:
   discussions-api: false
   discussions-db: false
   elasticsearch: false
+  feedback: false
   gateway: false
   indexer: false
   preview-map: false

--- a/deploy/helm/search-data-gov-au.yml
+++ b/deploy/helm/search-data-gov-au.yml
@@ -39,6 +39,8 @@ elasticsearch:
             requests:
                 cpu: 800m
                 memory: 6000Mi
+feedback-api:
+  gitHubIssuesUrl: "https://api.github.com/repos/TerriaJS/Magda-Feedback/issues"
 gateway:
     loadBalancerIP: "35.189.8.102"
     auth:

--- a/doc/deploying-for-production-on-gke.md
+++ b/doc/deploying-for-production-on-gke.md
@@ -10,6 +10,7 @@ NOTE: Work in progress... this probably won't work 100% for you. But it's a star
   - **indexer.elasticsearch.useGcsSnapshots**: Do you want to have elasticsearch snapshot to GCS? If so you'll need to create a GCS bucket for it, and set that in gcsSnapshotBucket. You'll also need to make sure your GKE cluster has access to GCS when you create it.
   - **gateway.loadBalancerIP**: What's the external IP you want to use?
   - **gateway.auth.x**: Put the ids of your google/facebook apps for OAuth if you have them. You'll also need to create an `oauth-secrets` secret containing a `facebook-client-secret` and `google-client-secret`.
+  - **feedback-api.gitHubIssuesUrl**: Put the API URL of your (private) GitHub repo where feedback issues will be created, e.g. `https://api.github.com/repos/TerriaJS/Magda-Feedback/issues`. You also need to create secret called `access-tokens` with a key `github-for-feedback` containing a personal access token with permissions to create issues in the private repo.
 
 5. Create db passwords (change the passwords and make them all different!):
 If `useCombinedDb=true`:

--- a/lerna.json
+++ b/lerna.json
@@ -16,6 +16,7 @@
         "magda-discussions-api/",
         "magda-discussions-db/",
         "magda-elastic-search/",
+        "magda-feedback-api/",
         "magda-gateway/",
         "magda-indexer/",
         "magda-int-test/",

--- a/magda-feedback-api/Dockerfile
+++ b/magda-feedback-api/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:6
+
+RUN mkdir -p /usr/src/app
+COPY . /usr/src/app
+WORKDIR /usr/src/app/component
+ENTRYPOINT [ "node", "/usr/src/app/component/dist/index.js" ]

--- a/magda-feedback-api/package.json
+++ b/magda-feedback-api/package.json
@@ -8,8 +8,7 @@
     "start": "node dist/index.js",
     "dev": "run-typescript-in-nodemon src/index.ts",
     "docker-build-local": "create-docker-context-for-node-component --build --push --tag auto --local",
-    "docker-build-prod": "create-docker-context-for-node-component --build --push --tag auto",
-    "test": "mocha --compilers ts:@magda/scripts/node_modules/ts-node/register --require @magda/scripts/node_modules/tsconfig-paths/register \"src/test/**/*.spec.ts\""
+    "docker-build-prod": "create-docker-context-for-node-component --build --push --tag auto"
   },
   "dependencies": {
     "body-parser": "^1.13.2",

--- a/magda-feedback-api/package.json
+++ b/magda-feedback-api/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "@magda/feedback-api",
+  "version": "0.0.33-0",
+  "scripts": {
+    "build": "npm run compile",
+    "compile": "tsc -p tsconfig-build.json",
+    "watch": "tsc -p tsconfig-build.json --watch",
+    "start": "node dist/index.js",
+    "dev": "run-typescript-in-nodemon src/index.ts",
+    "docker-build-local": "create-docker-context-for-node-component --build --push --tag auto --local",
+    "docker-build-prod": "create-docker-context-for-node-component --build --push --tag auto",
+    "test": "mocha --compilers ts:@magda/scripts/node_modules/ts-node/register --require @magda/scripts/node_modules/tsconfig-paths/register \"src/test/**/*.spec.ts\""
+  },
+  "dependencies": {
+    "body-parser": "^1.13.2",
+    "express": "^4.13.1",
+    "http-proxy": "^1.16.2",
+    "isomorphic-fetch": "^2.2.1",
+    "kubernetes-client": "3.17.2",
+    "lodash": "^4.17.4",
+    "request": "^2.67.0",
+    "util.promisify": "^1.0.0",
+    "yargs": "^8.0.2"
+  },
+  "devDependencies": {
+    "@magda/scripts": "^0.0.33-0",
+    "@types/chai": "^4.0.4",
+    "@types/config": "0.0.32",
+    "@types/express": "^4.0.35",
+    "@types/http-proxy": "^1.12.1",
+    "@types/lodash": "^4.14.74",
+    "@types/mocha": "^2.2.42",
+    "@types/nock": "^8.2.1",
+    "@types/node": "^8.0.14",
+    "@types/request": "^2.47.0",
+    "@types/sinon": "^2.3.3",
+    "@types/supertest": "^2.0.3",
+    "@types/yargs": "^8.0.2",
+    "chai": "^4.1.2",
+    "jsverify": "^0.8.2",
+    "mocha": "^3.5.0",
+    "nock": "^9.0.14",
+    "request-debug": "^0.2.0",
+    "sinon": "^3.2.1",
+    "supertest": "^3.0.0",
+    "typescript": "~2.4.0"
+  },
+  "config": {
+    "docker": {
+      "name": "data61/magda-feedback-api",
+      "include": "node_modules dist Dockerfile"
+    },
+    "jwtSecret": "squirrel",
+    "userId": "00000000-0000-4000-8000-000000000000"
+  }
+}

--- a/magda-feedback-api/src/index.ts
+++ b/magda-feedback-api/src/index.ts
@@ -35,7 +35,7 @@ const createIssueUrl = url.format(parsedCreateIssueUrl);
 var app = express();
 app.use(require("body-parser").json());
 
-app.post('/', function(req, res, next) {
+app.post('/v0', function(req, res, next) {
     var parameters = req.body;
 
     request({

--- a/magda-feedback-api/src/index.ts
+++ b/magda-feedback-api/src/index.ts
@@ -1,0 +1,83 @@
+import * as express from "express";
+import * as request from "request";
+import * as url from "url";
+import * as yargs from "yargs";
+
+const argv = yargs
+    .config()
+    .help()
+    .option("listenPort", {
+        describe: "The TCP/IP port on which the feedback api should listen.",
+        type: "number",
+        default: 6116
+    })
+    .option("userAgent", {
+        describe: "The user agent to use when contacting the GitHub API",
+        type: "string",
+        default: "Magda Feedback"
+    })
+    .option("issuesUrl", {
+        describe: "The GitHub issues URL in which to create feedback issues, such as https://api.github.com/repos/TerriaJS/Magda-Feedback/issues",
+        type: "string",
+        demand: true
+    })
+    .option("accessToken", {
+        describe: "The access token to use to interact with the GitHub API.",
+        type: "string",
+        demand: true
+    }).argv;
+
+const parsedCreateIssueUrl = url.parse(argv.issuesUrl, true);
+parsedCreateIssueUrl.query.access_token = argv.accessToken;
+const createIssueUrl = url.format(parsedCreateIssueUrl);
+
+// Create a new Express application.
+var app = express();
+app.use(require("body-parser").json());
+
+app.post('/', function(req, res, next) {
+    var parameters = req.body;
+
+    request({
+        url: createIssueUrl,
+        method: 'POST',
+        headers: {
+            'User-Agent': argv.userAgent,
+            'Accept': 'application/vnd.github.v3+json'
+        },
+        body: JSON.stringify({
+            title: parameters.title ? parameters.title : 'User Feedback',
+            body: formatBody(req, parameters)
+        })
+    }, function(error, response, body) {
+        res.set('Content-Type', 'application/json');
+        if (response.statusCode < 200 || response.statusCode >= 300) {
+            res.status(response.statusCode).send(JSON.stringify({result: 'FAILED'}));
+        } else {
+            res.status(200).send(JSON.stringify({result: 'SUCCESS'}));
+        }
+    });
+
+});
+
+app.listen(argv.listenPort);
+console.log("Feedback API started on port " + argv.listenPort);
+
+process.on("unhandledRejection", (reason: string, promise: any) => {
+    console.error(reason);
+});
+
+function formatBody(request: any, parameters: any) {
+    var result = '';
+
+    result += parameters.comment ? parameters.comment : 'No comment provided';
+    result += '\n### User details\n';
+    result += '* Name: '          + (parameters.name ? parameters.name : 'Not provided') + '\n';
+    result += '* Email Address: ' + (parameters.email ? parameters.email : 'Not provided') + '\n';
+    result += '* IP Address: '    + request.ip + '\n';
+    result += '* User Agent: '    + request.header('User-Agent') + '\n';
+    result += '* Referrer: '      + request.header('Referrer') + '\n';
+    result += '* Share URL: '     + (parameters.shareLink ? parameters.shareLink : 'Not provided') + '\n';
+
+    return result;
+}

--- a/magda-feedback-api/tsconfig-build.json
+++ b/magda-feedback-api/tsconfig-build.json
@@ -1,0 +1,11 @@
+{
+    "extends": "../tsconfig-global.json",
+    "compilerOptions": {
+        "declaration": true,
+        "outDir": "dist",
+        "baseUrl": "."
+    },
+    "include": [
+        "src"
+    ]
+}

--- a/magda-feedback-api/tsconfig.json
+++ b/magda-feedback-api/tsconfig.json
@@ -1,0 +1,8 @@
+{
+    "extends": "./tsconfig-build.json",
+    "compilerOptions": {
+        "baseUrl": ".",
+        "paths": {
+        }
+    }
+}

--- a/magda-gateway/local-routes.json
+++ b/magda-gateway/local-routes.json
@@ -24,5 +24,8 @@
     "admin": {
         "to": "http://localhost:6112/v0",
         "auth": true
+    },
+    "feedback": {
+        "to": "http://localhost:6116/v0"
     }
 }


### PR DESCRIPTION
### What this PR does

Adds a feedback service at `/api/v0/feedback` that works exactly like the terriajs-server one.

See the doc update in this PR for the Helm and K8S things you need to configure for it to actually create GitHub issues. If GitHub isn't configured properly, it just logs the feedback to the console instead.

### Checklist
* [x] Unit tests aren't applicable
* [x] I've updated CHANGES.md with what I changed.
* [ ] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column

I'm saying unit tests aren't applicable, but it's only sort of true. Mostly it's just not set up to be testable, nor is it really the sort of thing that tests are going to have much value for.

This is part of #475 I believe, but I haven't done any ZenHubbing.