### PR TITLE
Fixed up some css that got clobbered in a merge

### DIFF
--- a/magda-web-client/src/AppContainer.scss
+++ b/magda-web-client/src/AppContainer.scss
@@ -13,30 +13,21 @@
             margin-right: 10px;
             border-bottom: 0;
         }
+    }
 
-        .nav-bar-right {
-            float: right;
-            a {
-                display: inline-block;
-                margin-right: 10px;
-                border-bottom: 0;
-            }
-        }
-
-        .account-navbar {
+    .account-navbar {
+        display: inline-block;
+        a {
+            color: $body;
+            text-decoration: none;
+            border-bottom: 0;
+            transition: background-color 0.1s ease-in-out,
+                border-color 0.1s ease-in-out;
+            margin-right: 16px;
             display: inline-block;
-            a {
-                color: $body;
-                text-decoration: none;
-                border-bottom: 0;
-                transition: background-color 0.1s ease-in-out,
-                    border-color 0.1s ease-in-out;
-                margin-right: 16px;
-                display: inline-block;
-                &:hover,
-                &:focus {
-                    color: #fff;
-                }
+            &:hover,
+            &:focus {
+                color: #fff;
             }
         }
     }

--- a/magda-web-client/src/AppContainer.scss
+++ b/magda-web-client/src/AppContainer.scss
@@ -39,43 +39,44 @@
                 }
             }
         }
-        .logo a {
-            color: $body;
-            font-size: 18px;
-            font-weight: 500;
-            line-height: 22px;
-            text-transform: uppercase;
-            .highlight {
-                color: $main;
-            }
-        }
     }
 
-    .footer {
-        background-color: $magda-dark-blue;
+    .logo a {
+        color: $body;
+        font-size: 18px;
+        font-weight: 500;
+        line-height: 22px;
+        text-transform: uppercase;
+        .highlight {
+            color: $main;
+        }
+    }
+}
+
+.footer {
+    background-color: $magda-dark-blue;
+    color: #fff;
+    padding: 50px 0;
+    margin-top: 24px;
+    a {
         color: #fff;
-        padding: 50px 0;
-        margin-top: 24px;
-        a {
+        font-size: 0.9rem;
+    }
+    .nav > li > a {
+        padding: 10px 0px;
+        &:hover,
+        &:focus {
+            background: $magda;
             color: #fff;
-            font-size: 0.9rem;
         }
-        .nav > li > a {
-            padding: 10px 0px;
-            &:hover,
-            &:focus {
-                background: $magda;
-                color: #fff;
-            }
-        }
-        .nav-title {
-            text-transform: uppercase;
-        }
-        .copyright {
-            text-align: right;
-            img {
-                height: 40px;
-            }
+    }
+    .nav-title {
+        text-transform: uppercase;
+    }
+    .copyright {
+        text-align: right;
+        img {
+            height: 40px;
         }
     }
 }


### PR DESCRIPTION
### What this PR does
Some `{}`s ended up in the wrong place after a merge with formatting, this fixes it. Particular the footer and the 'data.gov.au' logo bit don't look right in the current master.

### Checklist
- [x] Unit tests aren't applicable (delete one)
- [x] there is no issue) and dragged