### PR TITLE
Allow acronyms for states in location filter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 ## 0.0.34
 
+* Added support to search for regions in the location filter by a short name and configured STE state regions to allow searching by acronym
+
 ## 0.0.33
 
 * Added ability to get records from the registry by the value of their aspects.

--- a/magda-int-test/src/test/scala/au/csiro/data61/magda/test/util/Generators.scala
+++ b/magda-int-test/src/test/scala/au/csiro/data61/magda/test/util/Generators.scala
@@ -204,6 +204,7 @@ object Generators {
     regionSource <- regionSourceGen.flatMap(Gen.oneOf(_))
     id <- Gen.uuid.map(_.toString)
     name <- textGen
+    shortName <- textGen
     geometry <- thisGeometryGen
     order <- Gen.posNum[Int]
   } yield (regionSource, JsObject(
@@ -212,7 +213,8 @@ object Generators {
     "order" -> JsNumber(order),
     "properties" -> JsObject(
       regionSource.idProperty -> JsString(id),
-      regionSource.nameProperty -> JsString(name))))
+      regionSource.nameProperty -> JsString(name),
+      regionSource.shortNameProperty.map(_ -> JsString(shortName)).toSeq: _* )))
 
   def pointGen(thisCoordGen: Gen[Coordinate] = coordGen()) = thisCoordGen.map(Point.apply)
   def multiPointGen(max: Int, thisCoordGen: Gen[Coordinate] = coordGen()) = listSizeBetween(1, max, thisCoordGen).map(MultiPoint.apply)

--- a/magda-int-test/src/test/scala/au/csiro/data61/magda/test/util/Generators.scala
+++ b/magda-int-test/src/test/scala/au/csiro/data61/magda/test/util/Generators.scala
@@ -211,9 +211,9 @@ object Generators {
     "type" -> JsString("Feature"),
     "geometry" -> GeometryFormat.write(geometry),
     "order" -> JsNumber(order),
-    "properties" -> JsObject(
+    "properties" -> JsObject(Seq(
       regionSource.idProperty -> JsString(id),
-      regionSource.nameProperty -> JsString(name),
+      regionSource.nameProperty -> JsString(name)) ++
       regionSource.shortNameProperty.map(_ -> JsString(shortName)).toSeq: _* )))
 
   def pointGen(thisCoordGen: Gen[Coordinate] = coordGen()) = thisCoordGen.map(Point.apply)

--- a/magda-int-test/src/test/scala/au/csiro/data61/magda/test/util/Generators.scala
+++ b/magda-int-test/src/test/scala/au/csiro/data61/magda/test/util/Generators.scala
@@ -148,6 +148,7 @@ object Generators {
     name <- Gen.uuid.map(_.toString)
     idProperty <- nonEmptyTextGen
     nameProperty <- nonEmptyTextGen
+    shortNameProperty <- noneBiasedOption(nonEmptyTextGen)
     includeIdInName <- arbitrary[Boolean]
     order <- Gen.posNum[Int]
   } yield RegionSource(
@@ -155,6 +156,7 @@ object Generators {
     url = new URL("http://example.com"),
     idProperty = idProperty,
     nameProperty = nameProperty,
+    shortNameProperty = shortNameProperty,
     includeIdInName = includeIdInName,
     disabled = false,
     order = order)

--- a/magda-scala-common/src/main/resources/common.conf
+++ b/magda-scala-common/src/main/resources/common.conf
@@ -68,6 +68,7 @@ regionSources = {
 		url = "https://s3-ap-southeast-2.amazonaws.com/magda-files/STE.geojson"
 		idField = "STE_CODE11"
 		nameField = "STE_NAME11"
+        shortNameField = "STE_ABBREV"
 		order = 10
 	}
 }

--- a/magda-scala-common/src/main/scala/au/csiro/data61/magda/search/elasticsearch/IndexDefinition.scala
+++ b/magda-scala-common/src/main/scala/au/csiro/data61/magda/search/elasticsearch/IndexDefinition.scala
@@ -129,6 +129,7 @@ object IndexDefinition extends DefaultJsonProtocol {
               field("regionType", KeywordType),
               field("regionId", KeywordType),
               magdaTextField("regionName"),
+              magdaTextField("regionShortName"),
               field("boundingBox", GeoShapeType),
               field("geometry", GeoShapeType),
               field("order", IntegerType)))
@@ -165,6 +166,7 @@ object IndexDefinition extends DefaultJsonProtocol {
           } else {
             properties.fields(regionSource.nameProperty)
           }
+          val shortName = regionSource.shortNameProperty.map(shortNameProp => properties.fields(shortNameProp).convertTo[String])
 
           val geometryOpt = jsonRegion.fields("geometry") match {
             case (jsGeometry: JsObject) =>
@@ -207,6 +209,7 @@ object IndexDefinition extends DefaultJsonProtocol {
                 "regionType" -> JsString(regionSource.name),
                 "regionId" -> JsString(id),
                 "regionName" -> name,
+                "regionShortName" -> shortName.map(JsString(_)).getOrElse(JsNull),
                 "boundingBox" -> createEnvelope(geometry).toJson(EsBoundingBoxFormat),
                 "geometry" -> geometry.toJson,
                 "order" -> JsNumber(regionSource.order)).toJson))

--- a/magda-scala-common/src/main/scala/au/csiro/data61/magda/spatial/RegionSource.scala
+++ b/magda-scala-common/src/main/scala/au/csiro/data61/magda/spatial/RegionSource.scala
@@ -12,6 +12,7 @@ case class RegionSource(
   url: URL,
   idProperty: String,
   nameProperty: String,
+  shortNameProperty: Option[String],
   includeIdInName: Boolean,
   disabled: Boolean,
   order: Int)
@@ -36,6 +37,7 @@ class RegionSources(config: Config) {
           url = new URL(regionSourceConfig.getString("url")),
           idProperty = regionSourceConfig.getString("idField"),
           nameProperty = regionSourceConfig.getString("nameField"),
+          shortNameProperty = if (regionSourceConfig.hasPath("shortNameField")) Some(regionSourceConfig.getString("shortNameField")) else None,
           includeIdInName = if (regionSourceConfig.hasPath("includeIdInName")) regionSourceConfig.getBoolean("includeIdInName") else false,
           disabled = regionSourceConfig.hasPath("disabled") && regionSourceConfig.getBoolean("disabled"),
           order = regionSourceConfig.getInt("order"))

--- a/magda-search-api/src/main/scala/au/csiro/data61/magda/search/elasticsearch/ElasticSearchQueryer.scala
+++ b/magda-search-api/src/main/scala/au/csiro/data61/magda/search/elasticsearch/ElasticSearchQueryer.scala
@@ -445,7 +445,7 @@ class ElasticSearchQueryer(indices: Indices = DefaultIndices)(
     clientFuture.flatMap { client =>
       client.execute(
         ElasticDsl.search(indices.getIndex(config, Indices.RegionsIndex) / indices.getType(Indices.RegionsIndexType))
-          query { matchPhrasePrefixQuery("regionName", query) }
+        query { boolQuery().should(matchPhrasePrefixQuery("regionShortName", query).boost(2), matchPhrasePrefixQuery("regionName", query)) }
           start start.toInt
           limit limit
           sortBy (


### PR DESCRIPTION
### What this PR does
Fixes #440.

Search for states by acronym in location filter
![magda state acronyms](https://user-images.githubusercontent.com/13863530/36774526-8a329a0e-1cb2-11e8-9f12-8d92fa3ca314.gif)


### Checklist
- [x] Unit tests aren't applicable
- [x] I've updated CHANGES.md with what I changed.
- [x] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column
- [ ] Fix test failure