### PR TITLE
Add logging to magda-web-server

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 ## 0.0.34
 
 * Made a click on the "Go back" link on the banner tag the user with a `noPreview` cookie for VWO to pick up on.
-* Added request logging `magda-web-server`
+* Added request logging to `magda-web-server`.
 
 ## 0.0.33
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 ## 0.0.34
 
 * Made a click on the "Go back" link on the banner tag the user with a `noPreview` cookie for VWO to pick up on.
+* Added request logging `magda-web-server`
 
 ## 0.0.33
 

--- a/magda-web-server/package.json
+++ b/magda-web-server/package.json
@@ -20,6 +20,7 @@
         "@types/express": "^4.0.39",
         "@types/lodash": "^4.14.68",
         "@types/mocha": "^2.2.41",
+        "@types/morgan": "^1.7.35",
         "@types/nock": "^8.2.1",
         "@types/sinon": "^2.3.3",
         "@types/supertest": "^2.0.2",
@@ -40,6 +41,7 @@
         "@magda/web-admin": "^0.0.34-0",
         "@magda/web-client": "^0.0.34-0",
         "express": "^4.15.3",
+        "morgan": "^1.9.0",
         "sitemap": "^1.13.0",
         "urijs": "^1.18.12",
         "yargs": "^8.0.2"

--- a/magda-web-server/src/index.ts
+++ b/magda-web-server/src/index.ts
@@ -2,6 +2,7 @@ import * as express from "express";
 import * as path from "path";
 import * as URI from "urijs";
 import * as yargs from "yargs";
+import * as morgan from "morgan";
 
 import Registry from "@magda/typescript-common/dist/registry/RegistryClient";
 
@@ -71,6 +72,8 @@ const argv = yargs
     }).argv;
 
 var app = express();
+
+app.use(morgan('combined'));
 
 const magda = path.join(__dirname, "..", "node_modules", "@magda");
 


### PR DESCRIPTION
### What this PR does
Fixes #466.
Adds logging to web server



### Checklist
- [x]Unit tests aren't applicable
- [x] I've updated CHANGES.md with what I changed. 
- [x] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column