### PR TITLE
Added default 60 second cache time for GETs in gateway.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
 * Added `onLoadingStart` & `onLoadingEnd` event handlers to the `DataPreviewMap` component of `magda-web-client` module.
 * Made a click on the "Go back" link on the banner tag the user with a `noPreview` cookie for VWO to pick up on.
 * Added request logging to `magda-web-server`.
+* Added default Cache-Control header to GET requests that go through the gateway.
 
 ## 0.0.33
 

--- a/magda-gateway/package.json
+++ b/magda-gateway/package.json
@@ -1,6 +1,7 @@
 {
     "name": "@magda/gateway",
-    "description": "The public gateway to all of MAGDA, including the API and web front end.",
+    "description":
+        "The public gateway to all of MAGDA, including the API and web front end.",
     "version": "0.0.34-0",
     "license": "Apache-2.0",
     "scripts": {
@@ -8,9 +9,12 @@
         "compile": "tsc -p tsconfig-build.json",
         "watch": "tsc -p tsconfig-build.json --watch",
         "start": "node dist/index.js",
-        "dev": "run-typescript-in-nodemon src/index.ts --ckanUrl https://data.gov.au",
-        "docker-build-local": "create-docker-context-for-node-component --build --push --tag auto --local",
-        "docker-build-prod": "create-docker-context-for-node-component --build --push --tag auto"
+        "dev":
+            "run-typescript-in-nodemon src/index.ts --ckanUrl https://data.gov.au",
+        "docker-build-local":
+            "create-docker-context-for-node-component --build --push --tag auto --local",
+        "docker-build-prod":
+            "create-docker-context-for-node-component --build --push --tag auto"
     },
     "dependencies": {
         "@magda/typescript-common": "^0.0.34-0",
@@ -45,6 +49,7 @@
         "@types/cors": "^2.8.1",
         "@types/ejs": "^2.3.33",
         "@types/express": "^4.0.37",
+        "@types/http-proxy": "^1.16.0",
         "@types/lodash": "^4.14.74",
         "@types/node": "^8.0.14",
         "@types/passport": "^0.3.4",

--- a/magda-gateway/src/createBaseProxy.ts
+++ b/magda-gateway/src/createBaseProxy.ts
@@ -1,0 +1,28 @@
+import * as httpProxy from "http-proxy";
+
+export default function createBaseProxy(): httpProxy {
+    const proxy = httpProxy.createProxyServer({ prependPath: false });
+
+    proxy.on("error", function(err: any, req: any, res: any) {
+        res.writeHead(500, {
+            "Content-Type": "text/plain"
+        });
+
+        console.error(err);
+
+        res.end("Something went wrong.");
+    });
+
+    proxy.on("proxyRes", function(proxyRes, req, res) {
+        // Add a default cache time of 60 seconds on GETs so the CDN can cache in times of high load.
+        if (
+            req.method === "GET" &&
+            !proxyRes.headers["Cache-Control"] &&
+            !proxyRes.headers["cache-control"]
+        ) {
+            proxyRes.headers["Cache-Control"] = "public, max-age=60";
+        }
+    });
+
+    return proxy;
+}

--- a/magda-gateway/src/createGenericProxy.ts
+++ b/magda-gateway/src/createGenericProxy.ts
@@ -1,15 +1,9 @@
 import * as express from "express";
-const httpProxy = require("http-proxy");
+import createBaseProxy from "./createBaseProxy";
 
-export default function createGenericProxy(target: {}): express.Router {
+export default function createGenericProxy(target: string): express.Router {
     const webRouter = express.Router();
-    const proxy = httpProxy.createProxyServer({ prependUrl: false });
-
-    proxy.on("error", function(err: any, req: any, res: any) {
-        console.error(err);
-
-        res.status(500).send("Something went wrong.");
-    });
+    const proxy = createBaseProxy();
 
     webRouter.get("*", (req: express.Request, res: express.Response) => {
         proxy.web(req, res, { target });


### PR DESCRIPTION
### What this PR does
Adds a 60 second `Cache-Control` header to GET responses that don't have anything set already.

I've found that etags are already being added to static files.

### Checklist
- [x] Unit tests aren't applicable
- [x] I've updated CHANGES.md with what I changed.
- [x] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column