### PR TITLE
issue 545 persist search text

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ## 0.0.37
 
+* Use params q= 'xxx' to persist the search text in search page, dataset page and distribution pages
 * Add CircleCI configuration to automatically build and deploy the public web interface
 * Hid `Projects` on header
 * Added recent searches function

--- a/magda-web-client/src/Components/Dataset/DatasetDetails.js
+++ b/magda-web-client/src/Components/Dataset/DatasetDetails.js
@@ -7,6 +7,7 @@ import StarRating from "../../UI/StarRating";
 import TagsBox from "../../UI/TagsBox";
 import { connect } from "react-redux";
 import DistributionRow from "../DistributionRow";
+import queryString from "query-string";
 import "./RecordDetails.css";
 import "./DatasetDetails.css";
 
@@ -17,7 +18,8 @@ class DatasetDetails extends Component {
     render() {
         const dataset = this.props.dataset;
         const datasetId = this.props.match.params.datasetId;
-
+        const searchText =
+            queryString.parse(this.props.location.search).q || "";
         const source = `This dataset was originally found on [${
             this.props.dataset.source
         }](${dataset.landingPage})`;
@@ -53,6 +55,7 @@ class DatasetDetails extends Component {
                                         key={s.identifier}
                                         distribution={s}
                                         datasetId={datasetId}
+                                        searchText={searchText}
                                     />
                                 ))}
                             </div>

--- a/magda-web-client/src/Components/Dataset/DatasetSummary.js
+++ b/magda-web-client/src/Components/Dataset/DatasetSummary.js
@@ -32,7 +32,7 @@ export default class DatasetSummary extends Component {
                         className="dataset-summary-title"
                         to={`/dataset/${encodeURIComponent(
                             dataset.identifier
-                        )}`}
+                        )}?q=${this.props.searchText}`}
                     >
                         {dataset.title}
                     </Link>

--- a/magda-web-client/src/Components/DistributionRow.js
+++ b/magda-web-client/src/Components/DistributionRow.js
@@ -117,7 +117,7 @@ class DistributionRow extends Component {
         const { datasetId, distribution } = this.props;
         const distributionLink = `/dataset/${encodeURIComponent(
             datasetId
-        )}/distribution/${encodeURIComponent(distribution.identifier)}`;
+        )}/distribution/${encodeURIComponent(distribution.identifier)}/?q=${this.props.searchText}`;
 
         return (
             <div className="distribution-row mui-row">

--- a/magda-web-client/src/Components/RecordHandler.js
+++ b/magda-web-client/src/Components/RecordHandler.js
@@ -11,7 +11,7 @@ import Tabs from "../UI/Tabs";
 import { config } from "../config";
 import ErrorHandler from "./ErrorHandler";
 import RouteNotFound from "./RouteNotFound";
-import { Route, Link, Switch, Redirect } from "react-router-dom";
+import { Route, Switch, Redirect } from "react-router-dom";
 import DatasetDetails from "./Dataset/DatasetDetails";
 import DistributionDetails from "./Dataset/DistributionDetails";
 import DistributionPreview from "./Dataset/DistributionPreview";
@@ -112,6 +112,10 @@ class RecordHandler extends React.Component {
                                     <Redirect
                                         from="/dataset/:datasetId/distribution/:distributionId"
                                         to={`${baseUrlDistribution}/details?q=${searchText}`}
+                                    />
+                                    <Redirect
+                                        from="/dataset/:datasetId/distribution/:distributionId/preview"
+                                        to={`${baseUrlDistribution}/preview?q=${searchText}`}
                                     />
                                 </Switch>
                             </div>

--- a/magda-web-client/src/Components/RecordHandler.js
+++ b/magda-web-client/src/Components/RecordHandler.js
@@ -15,6 +15,7 @@ import { Route, Link, Switch, Redirect } from "react-router-dom";
 import DatasetDetails from "./Dataset/DatasetDetails";
 import DistributionDetails from "./Dataset/DistributionDetails";
 import DistributionPreview from "./Dataset/DistributionPreview";
+import queryString from "query-string";
 import "./RecordHandler.css";
 
 class RecordHandler extends React.Component {
@@ -42,34 +43,12 @@ class RecordHandler extends React.Component {
         }
     }
 
-    renderBreadCrumbs(dataset, distribution) {
-        return (
-            <ul className="breadcrumb">
-                <li className="breadcrumb-item">
-                    <Link to="/">Home</Link>
-                </li>
-                <li className="breadcrumb-item">
-                    {distribution ? (
-                        <Link
-                            to={`/dataset/${encodeURIComponent(
-                                dataset.identifier
-                            )}`}
-                        >
-                            {dataset.title}
-                        </Link>
-                    ) : (
-                        dataset.title
-                    )}
-                </li>
-                {distribution && (
-                    <li className="breadcrumb-item">{distribution.title}</li>
-                )}
-            </ul>
-        );
-    }
+
 
     renderByState() {
         const publisherName = this.props.dataset.publisher.name;
+        const searchText =
+            queryString.parse(this.props.location.search).q || "";
         // const publisherId = this.props.dataset.publisher ? this.props.dataset.publisher.id : null;
         const distributionIdAsUrl = this.props.match.params.distributionId
             ? encodeURIComponent(this.props.match.params.distributionId)
@@ -132,7 +111,7 @@ class RecordHandler extends React.Component {
                                     />
                                     <Redirect
                                         from="/dataset/:datasetId/distribution/:distributionId"
-                                        to={`${baseUrlDistribution}/details`}
+                                        to={`${baseUrlDistribution}/details?q=${searchText}`}
                                     />
                                 </Switch>
                             </div>
@@ -149,11 +128,6 @@ class RecordHandler extends React.Component {
                         <ErrorHandler error={this.props.datasetFetchError} />
                     );
                 }
-                // const datasetTabs = [
-                //   {id: 'details', name: 'Details', isActive: true},
-                //   {id:  'discussion', name: 'Discussion', isActive: !config.disableAuthenticationFeatures},
-                //   {id: 'publisher', name: 'About ' + publisherName, isActive: publisherId},
-                // ];
 
                 const baseUrlDataset = `/dataset/${encodeURIComponent(
                     this.props.match.params.datasetId
@@ -193,7 +167,6 @@ class RecordHandler extends React.Component {
                                     </div>
                                 </div>
                             </div>
-
                             <div className="tab-content">
                                 <Switch>
                                     <Route
@@ -203,7 +176,7 @@ class RecordHandler extends React.Component {
                                     <Redirect
                                         exact
                                         from="/dataset/:datasetId"
-                                        to={`${baseUrlDataset}/details`}
+                                        to={`${baseUrlDataset}/details?q=${searchText}`}
                                     />
                                 </Switch>
                             </div>

--- a/magda-web-client/src/Components/RecordHandler.js
+++ b/magda-web-client/src/Components/RecordHandler.js
@@ -95,6 +95,7 @@ class RecordHandler extends React.Component {
                             <Tabs
                                 list={tabList}
                                 baseUrl={baseUrlDistribution}
+                                params={`q=${searchText}`}
                                 onTabChange={tab => {
                                     console.log(tab);
                                 }}
@@ -112,10 +113,6 @@ class RecordHandler extends React.Component {
                                     <Redirect
                                         from="/dataset/:datasetId/distribution/:distributionId"
                                         to={`${baseUrlDistribution}/details?q=${searchText}`}
-                                    />
-                                    <Redirect
-                                        from="/dataset/:datasetId/distribution/:distributionId/preview"
-                                        to={`${baseUrlDistribution}/preview?q=${searchText}`}
                                     />
                                 </Switch>
                             </div>

--- a/magda-web-client/src/Components/Search/Search.js
+++ b/magda-web-client/src/Components/Search/Search.js
@@ -183,6 +183,7 @@ class Search extends Component {
                                                     this.props.location.search
                                                 ).open
                                             }
+                                            searchText={searchText}
                                         />
                                         {this.props.hitCount >
                                             config.resultsPerPage && (

--- a/magda-web-client/src/Components/SearchResults/SearchResults.js
+++ b/magda-web-client/src/Components/SearchResults/SearchResults.js
@@ -24,7 +24,7 @@ class SearchResults extends Component {
                 <ul className="mui-list--unstyled">
                     {this.props.searchResults.map((result, i) => (
                         <li key={i} className="search-results__result">
-                            <DatasetSummary dataset={result} />
+                            <DatasetSummary dataset={result} searchText={this.props.searchText}/>
                         </li>
                     ))}
                 </ul>

--- a/magda-web-client/src/UI/Tabs.js
+++ b/magda-web-client/src/UI/Tabs.js
@@ -10,7 +10,7 @@ function Tabs(props) {
                     <li role="presentation" key={item.id}>
                         <NavLink
                             activeClassName="mui--is-active"
-                            to={`${props.baseUrl}/${item.id}`}
+                            to={`${props.baseUrl}/${item.id}?${props.params}`}
                             onClick={() => {
                                 props.onTabChange(item.id);
                             }}


### PR DESCRIPTION
### What this PR does
We use params `q= 'xxx'` to persist the search text in search page, dataset page and distribution pages. Reason being we already have the params `q`, it's more common and it's used by current dga