### PR TITLE
fix: allow <a> tags with target="_blank"

### DIFF
--- a/magda-web-server/src/index.ts
+++ b/magda-web-server/src/index.ts
@@ -100,7 +100,7 @@ app.use(
                 "rum-static.pingdom.net"
             ],
             objectSrc: ["'none'"],
-            sandbox: ["allow-scripts", "allow-same-origin"],
+            sandbox: ["allow-scripts", "allow-same-origin", "allow-popups"],
             reportUri: argv.baseUrl + "api/v0/feedback/csp"
         } as helmet.IHelmetContentSecurityPolicyDirectives,
         browserSniff: false


### PR DESCRIPTION
### What this PR does

A possible fix for `<a target="_blank">` won't open (#550 )

### Checklist
- [ ] There are unit tests to verify my changes are correct | Unit tests aren't applicable (delete one)
- [ ] I've updated CHANGES.md with what I changed.
- [ ] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column