### PR TITLE
Add CircleCI build for magda-web-client

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,82 @@
+version: 2
+jobs:
+  build_web:
+    docker:
+      #- image: circleci/openjdk:8-jdk-node-browsers
+      - image: circleci/node:9
+    steps:
+      - checkout
+#      - run:
+#          name: install sbt
+#          command: sudo apt-get install apt-transport-https
+#                   && echo "deb https://dl.bintray.com/sbt/debian /" | sudo tee -a /etc/apt/sources.list.d/sbt.list
+#                   && sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2EE0EA64E40A89B84B2DF73499E82A75642AC823
+#                   && sudo apt-get update
+#                   && sudo apt-get install sbt
+      - run:
+          name: install npm/lerna/eslint dev tools
+          command: 'sudo npm install -g npm@latest lerna eslint eslint-plugin-import eslint-plugin-flowtype eslint-plugin-jsx-a11y eslint-plugin-react eslint-config-react-app babel-eslint'
+      - restore_cache:
+          key: v1-dependency-cache-{{ checksum "magda-web-client/package.json" }}
+      - run:
+          name: lerna-bootstrap
+          command: lerna bootstrap
+      - save_cache:
+          key: v1-dependency-cache-{{ checksum "magda-web-client/package.json" }}
+          paths:
+            - ./node_modules
+            - ./magda-web-client/node_modules
+      - run:
+          name: set_api_url
+          command: sed -i.bak 's/http:\/\/magda-dev.terria.io/https:\/\/magda-dev.terria.io/g' magda-web-client/src/config.js
+      - run:
+          name: eslint
+          command: eslint magda-web-client/src/
+      - run:
+          name: npm build
+          command: cd magda-web-client && npm run build
+
+      - store_artifacts:
+          path: lerna-debug.log
+          path: magda-web-client/build
+      # Persist the specified paths into the workspace for use in downstream job.
+      - persist_to_workspace:
+          # Must be an absolute path, or relative path from working_directory. This is a directory on the container which is taken to be the root directory of the workspace.
+          root: magda-web-client
+          # Must be relative path from root
+          paths:
+            - manifest.yml
+            - build
+  deploy_web:
+    docker:
+      - image: circleci/node:9
+    steps:
+      - attach_workspace:
+          # Must be absolute path or relative path from working_directory
+          at: /tmp/workspace
+      - run: cd /tmp/workspace
+      - run: sudo apt-get install apt-transport-https
+      - run: wget -q -O - https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | sudo apt-key add -
+      - run: echo "deb https://packages.cloudfoundry.org/debian stable main" | sudo tee /etc/apt/sources.list.d/cloudfoundry-cli.list
+      - run: sudo apt-get update
+      - run: sudo apt-get install tree cf-cli
+      - run: cf install-plugin https://github.com/govau/autopilot/releases/download/0.0.5-venapp/autopilot-linux -f
+      - run: cf version
+      - run: cf login -a api.system.y.cld.gov.au -o dta -s data-gov-au -u $CF_USER -p $CF_PASSWORD
+      - run: cd /tmp/workspace && tree -C
+      #- run: cd /tmp/workspace && cf push -f manifest.yml
+      - run:  cd /tmp/workspace && cf zero-downtime-push magda-web-client -f manifest.yml
+
+workflows:
+  version: 2
+  build_and_deploy_web:
+    jobs:
+      - build_web
+      - deploy_web:
+          requires:
+            - build_web
+          filters:
+            branches:
+              only:
+                - master
+                - circleci

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 ## 0.0.35
 
+* Add CircleCI configuration to automatically build and deploy the public web interface
+
 ## 0.0.34
 
 * Added +x permissions to docker image scripts that didn't have them.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## 0.0.37
+
+* Add CircleCI configuration to automatically build and deploy the public web interface
+
 ## 0.0.36
 
 * Fixed a bug that stopped datasets with URL reserved characters in their id from being viewed.
@@ -5,7 +9,6 @@
 
 ## 0.0.35
 
-* Add CircleCI configuration to automatically build and deploy the public web interface
 * Fixed preview map data loading issue: replaced dev site url
 * Fixed `third-party.js` url in homepage
 

--- a/magda-web-client/manifest.yml
+++ b/magda-web-client/manifest.yml
@@ -1,0 +1,5 @@
+name: magda-web-client
+buildpack: staticfile_buildpack
+memory: 64M
+instances: 1
+path: ./build

--- a/magda-web-client/src/Components/CrappyChat/Plugins/UserMention/UserMentionSuggestions.js
+++ b/magda-web-client/src/Components/CrappyChat/Plugins/UserMention/UserMentionSuggestions.js
@@ -19,7 +19,7 @@ export default class UserMentionSuggestions extends React.Component {
     }
 
     onSearchChange(value) {
-        base
+        value
             .fetch("users", {
                 context: this,
                 asArray: true

--- a/magda-web-client/src/config.js
+++ b/magda-web-client/src/config.js
@@ -4,7 +4,7 @@ import Format from "./Components/SearchFacets/Format";
 import Region from "./Components/SearchFacets/Region";
 import Temporal from "./Components/SearchFacets/Temporal";
 
-const fallbackApiHost = "http://magda-dev.terria.io/";
+const fallbackApiHost = "https://magda-dev.terria.io/";
 
 const serverConfig: {
     authApiBaseUrl?: string,


### PR DESCRIPTION
### What this PR does
Add a build/deploy workflow for CircleCI to send magda-web-client static files to cloud.gov.au eg. https://magda-web-client.apps.y.cld.gov.au/

I was doing a full "npm run build" including scala/sbt tasks but commented out to make this faster for just one component deploy (potentially you could deploy even more apps to different URLs from one build in parallel)

Also you could probably could deploy magda-web-server as a node app instead but consider this a PoC ;) Monkeypatching the fallback API url to https because all cloud.gov.au apps are HTTPS only.

Includes some eslint-ing which found an issue in some "CrappyChat" code. Fixed.
There's also a warning "Definition for rule 'jsx-a11y/href-no-hash' was not found  jsx-a11y/href-no-hash" due to some out of date dependency https://github.com/facebook/create-react-app/pull/2930

### Checklist
- [x] Unit tests aren't applicable (delete one)
- [x] I've updated CHANGES.md with what I changed.
- [x] No issue from Zenhub/sprint