### PR TITLE
Download button/link click tracking via Google Analytics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 *.class
 *.log
 .classpath

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## 0.0.37
+
+* Added Download button/link click tracking via Google Analytics
+
 ## 0.0.36
 
 * Fixed a bug that stopped datasets with URL reserved characters in their id from being viewed.

--- a/magda-web-client/src/Components/Dataset/DistributionDetails.js
+++ b/magda-web-client/src/Components/Dataset/DistributionDetails.js
@@ -17,7 +17,7 @@ class DistributionDetails extends Component {
             ? <span>This dataset can be downloaded from: <br/>
                 <a onClick={(distribution) => {
                     // google analytics download tracking
-                    var resource_url = encodeURIComponent(distribution.downloadURL);
+                    const resource_url = encodeURIComponent(distribution.downloadURL);
                     if (resource_url && window.ga) {
                         window.ga('send', {
                             hitType: 'event',

--- a/magda-web-client/src/Components/Dataset/DistributionDetails.js
+++ b/magda-web-client/src/Components/Dataset/DistributionDetails.js
@@ -14,19 +14,28 @@ class DistributionDetails extends Component {
 
     renderLinkText(distribution) {
         const downloadText = distribution.downloadURL
-            ? `This dataset can be downloaded from: \n\n ${
-                  distribution.downloadURL
-              } ${this.renderLinkStatus(
-                  distribution.linkStatusAvailable,
-                  distribution.linkActive
-              )}`
+            ? <span>This dataset can be downloaded from: <br/>
+                <a onClick={(distribution) => {
+                    // google analytics download tracking
+                    var resource_url = encodeURIComponent(distribution.downloadURL);
+                    if (resource_url && window.ga) {
+                        window.ga('send', {
+                            hitType: 'event',
+                            eventCategory: 'Resource',
+                            eventAction: 'Download',
+                            eventLabel: resource_url
+                        })
+                    }
+                }} href={distribution.downloadURL}> {distribution.downloadURL}</a>
+                {this.renderLinkStatus(
+                    distribution.linkStatusAvailable,
+                    distribution.linkActive
+                )}</span>
             : "";
         const accessText = distribution.accessUrl
-            ? `This dataset can be accessed from: \n\n ${
-                  distribution.accessUrl
-              }`
+            ? <span>This dataset can be accessed from: <br/> <a href={distribution.accessUrl}>{distribution.accessUrl}</a></span>
             : "";
-        return downloadText + accessText;
+        return [downloadText , accessText];
     }
 
     render() {
@@ -42,11 +51,7 @@ class DistributionDetails extends Component {
                                 <div>
                                     {" "}
                                     <h3>Download</h3>
-                                    <OverviewBox
-                                        content={this.renderLinkText(
-                                            distribution
-                                        )}
-                                    />
+                                    {this.renderLinkText(distribution)}
                                 </div>
                             )}
                         </div>

--- a/magda-web-client/src/Components/DistributionRow.js
+++ b/magda-web-client/src/Components/DistributionRow.js
@@ -165,6 +165,17 @@ class DistributionRow extends Component {
                                 );
                                 return;
                             }
+
+                            // google analytics download tracking
+                            var resource_url = encodeURIComponent(distribution.downloadURL);
+                            if (resource_url && window.ga) {
+                                window.ga('send', {
+                                    hitType: 'event',
+                                    eventCategory: 'Resource',
+                                    eventAction: 'Download',
+                                    eventLabel: resource_url
+                                })
+                            }
                             window.location = distribution.downloadURL;
                         }}
                     >

--- a/magda-web-client/src/Components/DistributionRow.js
+++ b/magda-web-client/src/Components/DistributionRow.js
@@ -167,7 +167,7 @@ class DistributionRow extends Component {
                             }
 
                             // google analytics download tracking
-                            var resource_url = encodeURIComponent(distribution.downloadURL);
+                            const resource_url = encodeURIComponent(distribution.downloadURL);
                             if (resource_url && window.ga) {
                                 window.ga('send', {
                                     hitType: 'event',


### PR DESCRIPTION
### What this PR does
Download button/link click tracking via Google Analytics to be compatible with existing CKAN analytics data.

### Checklist
- [x] Unit tests aren't applicable
- [x] I've updated CHANGES.md with what I changed.
- [x] No Zenhub issue