### PR TITLE
Added footer link 'powered by magda' - #403

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,9 @@
 * Hid `Projects` on header
 * Added recent searches function
 * Set `node-sass` (required by magda-web-client) version to `4.8.1` to solve lerna bootstrap 404 error.
+* Added `Powered by magda` footer link
+* Modified `API Docs` footer link to use HTTPS
+
 ## 0.0.36
 
 * Fixed a bug that stopped datasets with URL reserved characters in their id from being viewed.

--- a/magda-web-client/src/config.js
+++ b/magda-web-client/src/config.js
@@ -105,7 +105,7 @@ export const config = {
                     "https://search.data.gov.au/api/v0/registry/swagger/index.html"
                 ],
                 [
-                    "Powered by magda",
+                    "Powered by Magda",
                     "https://github.com/TerriaJS/magda/"
                 ]
             ]

--- a/magda-web-client/src/config.js
+++ b/magda-web-client/src/config.js
@@ -102,7 +102,11 @@ export const config = {
             links: [
                 [
                     "API Docs",
-                    "http://search.data.gov.au/api/v0/registry/swagger/index.html"
+                    "https://search.data.gov.au/api/v0/registry/swagger/index.html"
+                ],
+                [
+                    "Powered by magda",
+                    "https://github.com/TerriaJS/magda/"
                 ]
             ]
         },


### PR DESCRIPTION
Should we use `magda`, `Magda` or `MAGDA` ? Assumed `magda`... `MAGDA` is too aggressive but it is an acronym?