### PR TITLE
Issue/591: Hidden the download button on dataset page when download url is not available

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@
 * Modified `API Docs` footer link to use HTTPS
 * Modified .vscode/settings to hide ALL `.css` files in @magda-web-client.
 * Added Rollbar exception reporting for client side javascript
+* Hidden download button on dataset page when download url is not available
 
 ## 0.0.36
 

--- a/magda-web-client/src/Components/DistributionRow.js
+++ b/magda-web-client/src/Components/DistributionRow.js
@@ -154,7 +154,7 @@ class DistributionRow extends Component {
                     </div>
                 </div>
                 <div className="mui-col-md-3 button-area">
-                    <Button
+                    {distribution.downloadURL ? (<Button
                         className="download-button"
                         onClick={() => {
                             if (!distribution.downloadURL) {
@@ -185,7 +185,7 @@ class DistributionRow extends Component {
                     >
                         <img src={downloadIcon} alt="download" />
                         <span className="button-text">Download</span>
-                    </Button>
+                    </Button>):null}
                     <Button
                         className="new-tab-button"
                         onClick={() => {


### PR DESCRIPTION
### What this PR does

fix: #591 

### Checklist
- [x] There are unit tests to verify my changes are correct | Unit tests aren't applicable (delete one)
- [x] I've updated CHANGES.md with what I changed.
- [x] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column