### PR TITLE
Stopped magda postgres failing to restart after a backup is interrupted

### DIFF
--- a/deploy/helm/magda/charts/authorization-db/templates/statefulset.yaml
+++ b/deploy/helm/magda/charts/authorization-db/templates/statefulset.yaml
@@ -32,9 +32,9 @@ spec:
         volumeMounts:
         - mountPath: /var/pv
           name: auth-data
-        {{- template "magda.waleGoogleStorageCredentials.volumeMount" . }}
+        {{- template "magda.waleVolumes.volumeMount" . }}
       volumes:
-      {{- template "magda.waleGoogleStorageCredentials.volume" . }}
+      {{- template "magda.waleVolumes.volume" . }}
   volumeClaimTemplates:
   - metadata:
       name: auth-data

--- a/deploy/helm/magda/charts/combined-db/templates/statefulset.yaml
+++ b/deploy/helm/magda/charts/combined-db/templates/statefulset.yaml
@@ -29,9 +29,9 @@ spec:
         volumeMounts:
         - name: combined-db
           mountPath: /var/pv
-        {{- template "magda.waleGoogleStorageCredentials.volumeMount" . }}
+        {{- template "magda.waleVolumes.volumeMount" . }}
       volumes:
-      {{- template "magda.waleGoogleStorageCredentials.volume" . }}
+      {{- template "magda.waleVolumes.volume" . }}
   volumeClaimTemplates:
   - metadata:
       name: combined-db

--- a/deploy/helm/magda/charts/discussions-db/templates/statefulset.yaml
+++ b/deploy/helm/magda/charts/discussions-db/templates/statefulset.yaml
@@ -32,9 +32,9 @@ spec:
         volumeMounts:
         - mountPath: /var/pv
           name: discussions-data
-        {{- template "magda.waleGoogleStorageCredentials.volumeMount" . }}
+        {{- template "magda.waleVolumes.volumeMount" . }}
       volumes:
-      {{- template "magda.waleGoogleStorageCredentials.volume" . }}
+      {{- template "magda.waleVolumes.volume" . }}
   volumeClaimTemplates:
   - metadata:
       name: discussions-data

--- a/deploy/helm/magda/charts/registry-db/templates/statefulset.yaml
+++ b/deploy/helm/magda/charts/registry-db/templates/statefulset.yaml
@@ -32,9 +32,9 @@ spec:
         volumeMounts:
         - mountPath: /var/pv
           name: registry-data
-        {{- template "magda.waleGoogleStorageCredentials.volumeMount" . }}
+        {{- template "magda.waleVolumes.volumeMount" . }}
       volumes:
-      {{- template "magda.waleGoogleStorageCredentials.volume" . }}
+      {{- template "magda.waleVolumes.volume" . }}
   volumeClaimTemplates:
   - metadata:
       name: registry-data

--- a/deploy/helm/magda/templates/_helpers.tpl
+++ b/deploy/helm/magda/templates/_helpers.tpl
@@ -111,27 +111,41 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
           value: {{ .Values.waleBackup.swiftAuthVersion }}
         - name: SWIFT_ENDPOINT_TYPE
           value: {{ .Values.waleBackup.swiftEndpointType }}
+        {{- if .Values.waleBackup.hostPath }}
+        - name: WALE_FILE_PREFIX
+          value: "file://localhost/var/backup"
+        {{- end }}
         - name: BACKUP_EXECUTION_TIME
           value: {{ .Values.waleBackup.executionTime }}
         {{- end }}
 {{- end }}
 
-{{- define "magda.waleGoogleStorageCredentials.volumeMount" }}
+{{- define "magda.waleVolumes.volumeMount" }}
 {{- if and .Values.waleBackup }}
 {{- if .Values.waleBackup.googleApplicationCreds }}
         - name: wale-google-account-credentials
           mountPath: "/var/{{ .Values.waleBackup.googleApplicationCreds.secretName }}"
           readOnly: true
 {{- end }}
+{{- if .Values.waleBackup.hostPath }}
+        - name: wale-backup-directory
+          mountPath: /var/backup
+{{- end }}
 {{- end }}
 {{- end }}
 
-{{- define "magda.waleGoogleStorageCredentials.volume" }}
+{{- define "magda.waleVolumes.volume" }}
 {{- if and .Values.waleBackup }}
 {{- if .Values.waleBackup.googleApplicationCreds }}
         - name: wale-google-account-credentials
           secret:
             secretName: {{ .Values.waleBackup.googleApplicationCreds.secretName }}
+{{- end }}
+{{- if .Values.waleBackup.hostPath }}
+        - name: wale-backup-directory
+          hostPath:
+            path: {{ .Values.waleBackup.hostPath }}
+            type: DirectoryOrCreate
 {{- end }}
 {{- end }}
 {{- end }}

--- a/deploy/helm/minikube-dev.yml
+++ b/deploy/helm/minikube-dev.yml
@@ -9,6 +9,32 @@ global:
   noDbAuth: true
   useCloudSql: false
   useCombinedDb: true
+
+tags:
+  all: false
+
+  combined-db: true
+  authorization-api: true
+  authorization-db: true
+  elasticsearch: true
+  gateway: true
+  indexer: true
+  preview-map: true
+  registry-api: true
+  registry-db: true
+  search-api: true
+  session-db: true
+  web-server: true
+  feedback-api: true
+  discussions-api: true
+  discussions-db: true
+  admin-api: true
+
+combined-db:
+  waleBackup:
+    method: WAL
+    hostPath: /Users/gil308/combined-db-backups
+    executionTime: 03:00
 gateway:
   auth:
     facebookClientId: "173073926555600"
@@ -24,3 +50,20 @@ registry-api:
   #   googleApplicationCreds:
   #     secretName: storage-account-credentials
   #     fileName: <fileName>
+
+sleuther-linked-data-rating:
+  resources:
+    limits:
+      cpu: 0.1
+sleuther-broken-link:
+  resources:
+    limits:
+      cpu: 0.1
+sleuther-visualization:
+  resources:
+    limits:
+      cpu: 0.1
+sleuther-format:
+  resources:
+    limits:
+      cpu: 0.1

--- a/deploy/helm/minikube-dev.yml
+++ b/deploy/helm/minikube-dev.yml
@@ -30,11 +30,6 @@ tags:
   discussions-db: true
   admin-api: true
 
-combined-db:
-  waleBackup:
-    method: WAL
-    hostPath: /Users/gil308/combined-db-backups
-    executionTime: 03:00
 gateway:
   auth:
     facebookClientId: "173073926555600"

--- a/magda-postgres/start.sh
+++ b/magda-postgres/start.sh
@@ -24,6 +24,9 @@ fi
 if [[ ! -z "${BACKUP}" ]]; then
     if [ ! -f "$PGDATA/recovery.done" ]; then
         wal-e backup-fetch $PGDATA LATEST
+    elif [ -f "$PGDATA/backup_label" ]; then
+        echo "Moving backup_label as we don't need to recover and it might interrupt startup"
+        mv "$PGDATA/backup_label" "$PGDATA/backup_label_$(date +%d-%m-%Y).dat"
     fi
 fi
 


### PR DESCRIPTION
### What this PR does
**Principally...**
... it stops the infamous `backup_label` problem in postgres, where if the server suddenly crashes during a backup, it'll cause a `backup_label` file to be left on the filesystem which intentionally stops the server from running. This makes sense in an environment where postgres servers are exquisitely cared for pets, but makes no sense for us, because our postgres server is cattle, and can be killed and restarted any time (🐮 🔫).

This means that if the postgres pod gets moved from node to node in the middle of the night when its backing up, it won't come back up until someone wakes up, edits the `command:` to `sleep 99999999999` so the server keeps running without postgres, `kubectl exec`s into the server and `rm`s the file, gets rid of the `sleep` command and restarts the pod. This is not ideal.

_However_ we can't just always delete the backup_label file because in my testing that causes recovery to fail, then you've got to do a bunch of scary stuff to get postgres going again.

_So_ now I've added a bit to the startup script that checks to see if we're recovering (by checking for the existence of `recovery.conf`. If so, do nothing, if not, delete the backup_label file before trying to startup.

**Also**: In testing this locally I added the ability to backup to a host volume instead of Google Storage et. al., and also made all the sleuthers disabled by default when running on minikube because they tend to max out the CPU and stop the front-end from working.

### Checklist
- [x] Unit tests aren't applicable
- [x] I've updated CHANGES.md with what I changed.
- [x] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column