### PR TITLE
Issue/662 Open in National Map button now send config via postMessage

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,7 @@
 * Hid download button on dataset page when download url is not available
 * Updated footer links and layout
 * Fixed an issue that prevents csv-geo-au data source to be openned in national map
+* Open in National Map button now send config via postMessage (except IE <=11)
 
 ## 0.0.36
 

--- a/magda-web-client/package.json
+++ b/magda-web-client/package.json
@@ -35,6 +35,7 @@
         "babel-preset-stage-0": "^6.24.1",
         "babel-preset-stage-2": "^6.24.1",
         "babel-root-slash-import": "^1.1.0",
+        "browser-detect": "^0.2.22",
         "deep-freeze": "0.0.1",
         "dompurify": "^1.0.2",
         "draft-js": "^0.10.1",

--- a/magda-web-client/src/UI/DataPreviewMapOpenInNationalMapButton.js
+++ b/magda-web-client/src/UI/DataPreviewMapOpenInNationalMapButton.js
@@ -73,7 +73,7 @@ class DataPreviewMapOpenInNationalMapButton extends Component {
         if (!newWinRef) {
             this.winRef = null;
             alert(
-                "The popup is blocked by popup blocker. Please change your browser settings and try again."
+                "Unable to open on National Map as it was blocked by a popup blocker. Please allow this site to open popups in your browser and try again."
             );
             return;
         }

--- a/magda-web-client/src/UI/DataPreviewMapOpenInNationalMapButton.js
+++ b/magda-web-client/src/UI/DataPreviewMapOpenInNationalMapButton.js
@@ -62,13 +62,13 @@ class DataPreviewMapOpenInNationalMapButton extends Component {
                             this.createCatalogItemFromDistribution(true)
                         )
                     ),
-                "National Map Australia"
+                "_blank"
             );
             return;
         }
         const newWinRef = window.open(
             "https://nationalmap.gov.au",
-            "National Map Australia"
+            "_blank"
         );
         if (!newWinRef) {
             this.winRef = null;

--- a/magda-web-client/src/UI/DataPreviewMapOpenInNationalMapButton.js
+++ b/magda-web-client/src/UI/DataPreviewMapOpenInNationalMapButton.js
@@ -66,10 +66,7 @@ class DataPreviewMapOpenInNationalMapButton extends Component {
             );
             return;
         }
-        const newWinRef = window.open(
-            "https://nationalmap.gov.au",
-            "_blank"
-        );
+        const newWinRef = window.open("https://nationalmap.gov.au", "_blank");
         if (!newWinRef) {
             this.winRef = null;
             alert(


### PR DESCRIPTION
### What this PR does

Fixed #662 

Open in National Map button now send config via postMessage
I think @kring was right. `postMessage` does work.
For IE <=11, still via URL as poor support on postMessage between popup windows
See: https://caniuse.com/#search=postMessage

### Checklist
- [x] There are unit tests to verify my changes are correct | Unit tests aren't applicable (delete one)
- [x] I've updated CHANGES.md with what I changed.
- [x] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column