### PR TITLE
Made snapshots directory work in ES again.

### DIFF
--- a/deploy/helm/search-data-gov-au.yml
+++ b/deploy/helm/search-data-gov-au.yml
@@ -54,11 +54,6 @@ gateway:
         requests:
             cpu: 200m
             memory: 200Mi
-indexer:
-    resources:
-        requests:
-            cpu: 200m
-            memory: 200Mi
 preview-map:
     replicas: 2
     resources:
@@ -158,6 +153,10 @@ indexer:
 #    useGcsSnapshots: true
 #    gcsSnapshotBucket: "magda-es-snapshots"
 #    gcsSnapshotServiceAccount: "_default"
+  resources:
+    requests:
+      cpu: 200m
+      memory: 200Mi
 feedback-api:
     gitHubIssuesUrl: "https://api.github.com/repos/TerriaJS/Magda-Feedback/issues"
     replicas: 2

--- a/magda-elastic-search/Dockerfile
+++ b/magda-elastic-search/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/pires/docker-elasticsearch-kubernetes:5.6.3
 
-VOLUME /snapshots
-
-ENV REPO /snapshots
-
 ADD component/elasticsearch.yml /elasticsearch/config/elasticsearch.yml
+ADD component/setup.sh /setup.sh
+RUN apk add --no-cache --update curl procps
+
+CMD ["/setup.sh"]

--- a/magda-elastic-search/package.json
+++ b/magda-elastic-search/package.json
@@ -15,7 +15,7 @@
     "config": {
         "docker": {
             "name": "data61/magda-elasticsearch",
-            "include": "Dockerfile elasticsearch.yml"
+            "include": "Dockerfile elasticsearch.yml setup.sh"
         }
     },
     "devDependencies": {


### PR DESCRIPTION
### What this PR does
Stops elasticsearch failing when new indices are created because it can't find a /snapshots dir.
