### PR TITLE
Issue/727: Empty search won't be saved as recent search item

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 *   Will Scroll to top of the page when goes from link to link
 *   Dataset page: Change icon for distribution page
+*   Empty search won't be saved as recent search item
 
 ## 0.0.37
 

--- a/magda-web-client/src/Components/Search/SearchSuggestionBox.js
+++ b/magda-web-client/src/Components/Search/SearchSuggestionBox.js
@@ -136,6 +136,7 @@ class SearchSuggestionBox extends Component {
     saveRecentSearch(newProps) {
         const searchData = this.createSearchDataFromProps(newProps);
         if (!searchData) return;
+        if (!searchData.data.q || !searchData.data.q.trim()) return;
         const recentSearches = this.insertItemIntoLocalData(
             "recentSearches",
             searchData


### PR DESCRIPTION
### What this PR does

Related issue: #727 

### Checklist
- [x] There are unit tests to verify my changes are correct | Unit tests aren't applicable (delete one)
- [x] I've updated CHANGES.md with what I changed.
- [x] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column