### PR TITLE
Issue/582 filters disappearing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 *   Removed excess vertical whitespace from hamburger menu
 *   Dataset page: Change icon for distribution page
 *   Empty search won't be saved as recent search item
+*   Stopped filters from disappearing when search is submitted
 
 ## 0.0.37
 

--- a/magda-web-client/src/actions/datasetSearchActions.js
+++ b/magda-web-client/src/actions/datasetSearchActions.js
@@ -44,7 +44,6 @@ export function resetDatasetSearch(): SearchAction {
 export function fetchSearchResults(query: string): Store {
     return (dispatch: Dispatch) => {
         let url: string = config.searchApiUrl + `datasets?${query}`;
-        dispatch(requestResults(query));
         return fetch(url)
             .then((response: Object) => {
                 if (response.status === 200) {

--- a/magda-web-client/src/reducers/datasetSearchReducer.js
+++ b/magda-web-client/src/reducers/datasetSearchReducer.js
@@ -45,20 +45,6 @@ const datasetSearchReducer = (
     action: SearchAction
 ) => {
     switch (action.type) {
-        case "REQUEST_RESULTS":
-            return Object.assign({}, state, {
-                isFetching: true,
-                error: null,
-                apiQuery: action.apiQuery && action.apiQuery,
-                temporalRange: initialData.temporalRange,
-                publisherOptions: initialData.publisherOptions,
-                formatOptions: initialData.formatOptions,
-                activePublishers: initialData.activePublishers,
-                activeRegion: initialData.activeRegion,
-                activeDateFrom: initialData.activeDateFrom,
-                activeDateTo: initialData.activeDateTo,
-                activeFormats: initialData.activeFormats
-            });
         case "FETCH_ERROR":
             return Object.assign({}, state, {
                 isFetching: false,


### PR DESCRIPTION
### What this PR does
Everytime a search was performed and action was dispatched which reset the state of the filters to initial null state. I've stopped this action from dispatching.


### Checklist
- [x] There are unit tests to verify my changes are correct | Unit tests aren't applicable (delete one)
- [x] I've updated CHANGES.md with what I changed.
- [x] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column