### PR TITLE
Issue/748: Fixed an issue that accessURL won't be displayed on distribution page

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
 *   Removed excess vertical whitespace from hamburger menu
 *   Dataset page: Change icon for distribution page
 *   Empty search won't be saved as recent search item
+*   Fixed an issue that accessURL won't be displayed on distribution page.
+*   Will not show distribution page if only accessURL is available.
 
 ## 0.0.37
 

--- a/magda-web-client/src/Components/Dataset/DistributionDetails.js
+++ b/magda-web-client/src/Components/Dataset/DistributionDetails.js
@@ -44,15 +44,18 @@ class DistributionDetails extends Component {
         ) : (
             ""
         );
-        const accessText = distribution.accessUrl ? (
+        const accessText = distribution.accessURL ? (
             <span>
                 This dataset can be accessed from: <br />{" "}
-                <a href={distribution.accessUrl}>{distribution.accessUrl}</a>
+                <a href={distribution.accessURL}>{distribution.accessURL}</a>
             </span>
         ) : (
             ""
         );
-        return [downloadText, accessText];
+        const items = [];
+        if(downloadText) items.push(downloadText);
+        if(accessText) items.push(accessText);
+        return items;
     }
 
     render() {

--- a/magda-web-client/src/Components/Dataset/DistributionDetails.js
+++ b/magda-web-client/src/Components/Dataset/DistributionDetails.js
@@ -53,8 +53,8 @@ class DistributionDetails extends Component {
             ""
         );
         const items = [];
-        if(downloadText) items.push(downloadText);
-        if(accessText) items.push(accessText);
+        if (downloadText) items.push(downloadText);
+        if (accessText) items.push(accessText);
         return items;
     }
 

--- a/magda-web-client/src/Components/DistributionRow.js
+++ b/magda-web-client/src/Components/DistributionRow.js
@@ -145,16 +145,20 @@ class DistributionRow extends Component {
 
                         <div className="mui-col-md-11">
                             <div className="distribution-row-link">
-                                {
-                                    (!distribution.downloadURL && distribution.accessURL) ?
-                                    (
-                                        <div>{distribution.title}({distribution.format})</div>
-                                    ):(
-                                        <Link to={distributionLink}>
-                                            {distribution.title}({distribution.format})
-                                        </Link>
-                                    )
-                                }
+                                {!distribution.downloadURL &&
+                                distribution.accessURL ? (
+                                    <div>
+                                        {distribution.title}({
+                                            distribution.format
+                                        })
+                                    </div>
+                                ) : (
+                                    <Link to={distributionLink}>
+                                        {distribution.title}({
+                                            distribution.format
+                                        })
+                                    </Link>
+                                )}
                             </div>
 
                             <div className="distribution-row-link-license">

--- a/magda-web-client/src/Components/DistributionRow.js
+++ b/magda-web-client/src/Components/DistributionRow.js
@@ -50,6 +50,10 @@ const CategoryDetermineConfigItems = [
         category: "html"
     },
     {
+        regex: /^www:/,
+        category: "html"
+    },
+    {
         regex: /jpg|gif|jpeg/,
         category: "image-raster"
     },
@@ -115,11 +119,15 @@ class DistributionRow extends Component {
 
     render() {
         const { datasetId, distribution } = this.props;
-        const distributionLink = `/dataset/${encodeURIComponent(
-            datasetId
-        )}/distribution/${encodeURIComponent(distribution.identifier)}/?q=${
-            this.props.searchText
-        }`;
+        let distributionLink;
+        if (!distribution.downloadURL && distribution.accessURL)
+            distributionLink = distribution.accessURL;
+        else
+            distributionLink = `/dataset/${encodeURIComponent(
+                datasetId
+            )}/distribution/${encodeURIComponent(distribution.identifier)}/?q=${
+                this.props.searchText
+            }`;
 
         return (
             <div className="distribution-row mui-row">
@@ -137,9 +145,16 @@ class DistributionRow extends Component {
 
                         <div className="mui-col-md-11">
                             <div className="distribution-row-link">
-                                <Link to={distributionLink}>
-                                    {distribution.title}({distribution.format})
-                                </Link>
+                                {
+                                    (!distribution.downloadURL && distribution.accessURL) ?
+                                    (
+                                        <div>{distribution.title}({distribution.format})</div>
+                                    ):(
+                                        <Link to={distributionLink}>
+                                            {distribution.title}({distribution.format})
+                                        </Link>
+                                    )
+                                }
                             </div>
 
                             <div className="distribution-row-link-license">


### PR DESCRIPTION
### What this PR does

- Fixed an issue that accessURL won't be displayed on distribution page (#748 )
- Will not show distribution page if only accessURL is available. (#731 )

### Checklist
- [x] There are unit tests to verify my changes are correct | Unit tests aren't applicable (delete one)
- [x] I've updated CHANGES.md with what I changed.
- [x] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column