### PR TITLE
Add a DGA inspired spinner for loading states

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 *   Removed excess vertical whitespace from hamburger menu
 *   Dataset page: Change icon for distribution page
 *   Empty search won't be saved as recent search item
+*   Added loading spinner for preview map.
 
 ## 0.0.37
 

--- a/magda-web-client/src/Components/Spinner.js
+++ b/magda-web-client/src/Components/Spinner.js
@@ -1,0 +1,18 @@
+import React from "react";
+import "./Spinner.css";
+
+export default function Spinner() {
+    return (
+        <div className="sk-cube-grid">
+            <div className="sk-cube sk-cube1" />
+            <div className="sk-cube sk-cube2" />
+            <div className="sk-cube sk-cube3" />
+            <div className="sk-cube sk-cube4" />
+            <div className="sk-cube sk-cube5" />
+            <div className="sk-cube sk-cube6" />
+            <div className="sk-cube sk-cube7" />
+            <div className="sk-cube sk-cube8" />
+            <div className="sk-cube sk-cube9" />
+        </div>
+    );
+}

--- a/magda-web-client/src/Components/Spinner.scss
+++ b/magda-web-client/src/Components/Spinner.scss
@@ -1,0 +1,117 @@
+// Adapted from https://github.com/tobiasahlin/SpinKit
+// Licence:
+// The MIT License (MIT)
+
+// Copyright (c) 2015 Tobias Ahlin
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+/*
+ *  Usage:
+ *
+      <div class="sk-cube-grid">
+        <div class="sk-cube sk-cube1"></div>
+        <div class="sk-cube sk-cube2"></div>
+        <div class="sk-cube sk-cube3"></div>
+        <div class="sk-cube sk-cube4"></div>
+        <div class="sk-cube sk-cube5"></div>
+        <div class="sk-cube sk-cube6"></div>
+        <div class="sk-cube sk-cube7"></div>
+        <div class="sk-cube sk-cube8"></div>
+        <div class="sk-cube sk-cube9"></div>
+      </div>
+ *
+ */
+
+@import "../variables";
+
+.sk-cube-grid {
+    width: 40px;
+    height: 40px;
+    margin: 40px auto;
+    /*
+     * Spinner positions
+     * 1 2 3
+     * 4 5 6
+     * 7 8 9
+     */
+}
+.sk-cube-grid .sk-cube {
+    width: 30%;
+    height: 30%;
+    margin: 0px 0px 1px 1px;
+    background-color: $main;
+    border: 1px solid $main;
+    box-sizing: border-box;
+    border-radius: 2px;
+    float: left;
+    animation: sk-cubeGridScaleDelay 1.3s infinite ease-in-out;
+}
+
+.sk-cube-grid .sk-cube:nth-child(even) {
+    background-color: white;
+}
+.sk-cube-grid .sk-cube1 {
+    animation-delay: 0.2s;
+}
+.sk-cube-grid .sk-cube2 {
+    animation-delay: 0.3s;
+}
+.sk-cube-grid .sk-cube3 {
+    animation-delay: 0.4s;
+}
+.sk-cube-grid .sk-cube4 {
+    animation-delay: 0.1s;
+}
+.sk-cube-grid .sk-cube5 {
+    animation-delay: 0.2s;
+}
+.sk-cube-grid .sk-cube6 {
+    animation-delay: 0.3s;
+}
+.sk-cube-grid .sk-cube7 {
+    animation-delay: 0s;
+}
+.sk-cube-grid .sk-cube8 {
+    animation-delay: 0.1s;
+}
+.sk-cube-grid .sk-cube9 {
+    animation-delay: 0.2s;
+}
+
+@-webkit-keyframes sk-cubeGridScaleDelay {
+    0%,
+    70%,
+    100% {
+        transform: scale3D(1, 1, 1);
+    }
+    35% {
+        transform: scale3D(0, 0, 1);
+    }
+}
+
+@keyframes sk-cubeGridScaleDelay {
+    0%,
+    70%,
+    100% {
+        transform: scale3D(1, 1, 1);
+    }
+    35% {
+        transform: scale3D(0, 0, 1);
+    }
+}

--- a/magda-web-client/src/UI/DataPreviewMap.js
+++ b/magda-web-client/src/UI/DataPreviewMap.js
@@ -4,6 +4,7 @@ import "./DataPreviewMap.css";
 import DataPreviewMapOpenInNationalMapButton from "./DataPreviewMapOpenInNationalMapButton";
 import { config } from "../config";
 import { Medium, Small } from "./Responsive";
+import Spinner from "../Components/Spinner";
 
 export const defaultDataSourcePreference = [
     "WMS",
@@ -18,6 +19,7 @@ class DataPreviewMap extends Component {
         super(props);
         this.state = {
             isInitLoading: true,
+            isMapLoading: false,
             isMapPreviewAvailable: false,
             selectedDistribution: null
         };
@@ -32,6 +34,7 @@ class DataPreviewMap extends Component {
         if (identifier === "") {
             this.setState({
                 isInitLoading: true,
+                isMapLoading: false,
                 isMapPreviewAvailable: false,
                 selectedDistribution: null
             });
@@ -48,6 +51,7 @@ class DataPreviewMap extends Component {
         } else {
             this.setState({
                 isInitLoading: false,
+                isMapLoading: true,
                 isMapPreviewAvailable: true,
                 selectedDistribution: selectedDistribution
             });
@@ -140,6 +144,9 @@ class DataPreviewMap extends Component {
                 this.createCatalogItemFromDistribution(),
                 "*"
             );
+            this.setState({
+                isMapLoading: true
+            });
             if (this.props.onLoadingStart) {
                 try {
                     this.props.onLoadingStart();
@@ -149,6 +156,9 @@ class DataPreviewMap extends Component {
             }
             return;
         } else if (e.data === "loading complete") {
+            this.setState({
+                isMapLoading: false
+            });
             if (this.props.onLoadingEnd) {
                 try {
                     this.props.onLoadingEnd();
@@ -161,26 +171,27 @@ class DataPreviewMap extends Component {
     }
 
     render() {
-        if (this.state.isInitLoading)
-            return (
-                <div className="data-preview-map">
-                    <h3>Map Preview</h3>
-                    Loading....
-                </div>
-            );
+        if (!this.state.isInitLoading && !this.state.isMapPreviewAvailable)
+            return null; //-- requested by Tash: hide the section if no data available
 
-        if (!this.state.isMapPreviewAvailable) return null; //-- requested by Tash: hide the section if no data available
+        // 3 states:
+        // - loading component (isInitLoading === true) -> Show spinner
+        // - loading terria (isMapLoading === true) -> Continue showing spinner and start loading map hidden
+        // - everything loaded (neither true) -> No spinner, show map
 
-        return (
-            <div className="data-preview-map">
-                <h3>Map Preview</h3>
+        let iframe = null;
+        if (!this.state.isInitLoading) {
+            iframe = (
                 <div style={{ position: "relative" }}>
                     <DataPreviewMapOpenInNationalMapButton
                         distribution={this.state.selectedDistribution}
                         style={{
                             position: "absolute",
                             right: "10px",
-                            top: "10px"
+                            top: "10px",
+                            visibility: this.state.isMapLoading
+                                ? "hidden"
+                                : "visible"
                         }}
                     />
                     <Medium>
@@ -194,6 +205,11 @@ class DataPreviewMap extends Component {
                                 "#mode=preview&hideExplorerPanel=1&clean"
                             }
                             ref={f => (this.iframeRef = f)}
+                            style={{
+                                visibility: this.state.isMapLoading
+                                    ? "hidden"
+                                    : "visible"
+                            }}
                         />
                     </Medium>
                     <Small>
@@ -207,9 +223,24 @@ class DataPreviewMap extends Component {
                                 "#mode=preview&hideExplorerPanel=1&clean"
                             }
                             ref={f => (this.iframeRef = f)}
+                            style={{
+                                visibility: this.state.isMapLoading
+                                    ? "hidden"
+                                    : "visible"
+                            }}
                         />
                     </Small>
                 </div>
+            );
+        }
+
+        return (
+            <div className="data-preview-map">
+                <h3>Map Preview</h3>
+                {(this.state.isInitLoading || this.state.isMapLoading) && (
+                    <Spinner />
+                )}
+                {iframe}
             </div>
         );
     }


### PR DESCRIPTION
### What this PR does
Partially implements #455.

Add a spinner inspired by the dga logo and use it as a loading state for the map.
Check it out here: http://magda-dga-spinner.surge.sh/dataset/ds-dga-346f0794-8834-4a42-94be-9256f663e731/details?q=city

### Checklist
- [x] Unit tests aren't applicable
- [x] I've updated CHANGES.md with what I changed.
- [x] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column