### PR TITLE
Added margin-bottom spacing for footer links on mobile

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,12 +18,13 @@
 *   Fixed an issue that registry excludes linking aspects when there are no links
 *   Visual adjustments on Homepage & dataset page
 *   Changes on homepage config: different background & lozenge on different day
-*   Allow turn off homepage stories by set stories field to null 
+*   Allow turn off homepage stories by set stories field to null
 *   Remove 'unspecified' item from publisher & format aggregation
 *   Added file icon hover tooltip on dataset page
 *   Brought back mobile version home page story style to avoid being run into each other
 *   Updated text for homepage articles.
 *   Update Privacy/About/Data Rating pages
+*   Added `margin-bottom` spacing for footer links on mobile.
 
 ## 0.0.37
 
@@ -69,7 +70,7 @@
 *   Changed "request dataset" link in footer to a mailto link
 *   Added the data.gov.au s3 bucket to allowed script sources
 *   Added feedback uri to server config.
-*   Modified search results `Quality:` text to `Open Data Quality:` 
+*   Modified search results `Quality:` text to `Open Data Quality:`
 *   Added eslint to travis build
 *   Created `ISSUE_TEMPLATE.md` file
 

--- a/magda-web-client/src/AppContainer.scss
+++ b/magda-web-client/src/AppContainer.scss
@@ -35,10 +35,17 @@
             /* ./index.scss defines a border-bottom, this overrides that */
             border-bottom-style: none;
         }
-        
+
         a:hover {
             /* ./index.scss defines a background-color, this overrides that */
             background-color: transparent;
         }
+    }
+}
+
+/* On mobile, add margin-bottom spacing to footer links */
+@media screen and (max-width: ($medium - 1)) {
+    .mui-list--unstyled > li {
+        margin-bottom: 1em;
     }
 }


### PR DESCRIPTION
### What this PR does
Add `margin-bottom: 1em` spacing to footer links on mobile view


### Checklist
- [x] Unit tests aren't applicable
- [x] I've updated CHANGES.md with what I changed.
- [x] I've linked this PR to an issue in ZenHub