### PR TITLE
Removed box-shadow from search facet button

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,12 +18,13 @@
 *   Fixed an issue that registry excludes linking aspects when there are no links
 *   Visual adjustments on Homepage & dataset page
 *   Changes on homepage config: different background & lozenge on different day
-*   Allow turn off homepage stories by set stories field to null 
+*   Allow turn off homepage stories by set stories field to null
 *   Remove 'unspecified' item from publisher & format aggregation
 *   Added file icon hover tooltip on dataset page
 *   Brought back mobile version home page story style to avoid being run into each other
 *   Updated text for homepage articles.
 *   Update Privacy/About/Data Rating pages
+*   Removed `box-shadow` style from selected search facets buttons
 
 ## 0.0.37
 
@@ -69,7 +70,7 @@
 *   Changed "request dataset" link in footer to a mailto link
 *   Added the data.gov.au s3 bucket to allowed script sources
 *   Added feedback uri to server config.
-*   Modified search results `Quality:` text to `Open Data Quality:` 
+*   Modified search results `Quality:` text to `Open Data Quality:`
 *   Added eslint to travis build
 *   Created `ISSUE_TEMPLATE.md` file
 

--- a/magda-web-client/src/Components/SearchFacets/SearchFacets.scss
+++ b/magda-web-client/src/Components/SearchFacets/SearchFacets.scss
@@ -76,7 +76,6 @@
     &:hover,
     &:focus {
         background-color: rgba(245, 88, 96, 0.1);
-        box-shadow: inset 0 -1px 0 0 rgba(73, 73, 73, 0.1);
     }
 }
 


### PR DESCRIPTION
### What this PR does
Removed the `box-shadow` property from the search facet button.

## Before:
<img width="362" alt="screen shot 2018-04-17 at 2 07 50 pm" src="https://user-images.githubusercontent.com/1501560/38848259-87d75242-4249-11e8-8532-2244d6b71d16.png">

## After:
<img width="362" alt="screen shot 2018-04-17 at 2 07 35 pm" src="https://user-images.githubusercontent.com/1501560/38848263-8c676b6c-4249-11e8-88bf-d0650ad1f2cd.png">

### Checklist
- [x] Unit tests aren't applicable
- [x] I've updated CHANGES.md with what I changed.
- [x] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column