### PR TITLE
Issue/652 Upgraded TerriaJs to 5.7.0 for issue #652

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,7 @@
 *   Added `margin-bottom` spacing for footer links on mobile.
 *   Removed `box-shadow` style from selected search facets buttons
 *   If format info is available from sleuther, format sleuther info should be used
+*   Upgraded TerriaJs to 5.7.0 to fix the issue with previewing certain datasets
 
 ## 0.0.37
 

--- a/magda-preview-map/package.json
+++ b/magda-preview-map/package.json
@@ -67,7 +67,7 @@
         "svg-baker": "^1.2.17",
         "svg-baker-runtime": "^1.3.3",
         "svg-sprite-loader": "^3.4.0",
-        "terriajs": "5.6.0",
+        "terriajs": "5.7.0",
         "terriajs-catalog-editor": "^0.2.0",
         "terriajs-cesium": "1.41.1",
         "terriajs-schema": "latest",


### PR DESCRIPTION
### What this PR does

When previewing some spatial data, the user might see an error: 
`This dataset is already shown` (issue #652)

TerriaJs has been upgraded to include a fix for this.

Have tested build result in a travis docker contrainer and works ok.

### Checklist
- [x] Unit tests aren't applicable (delete one)
- [x] I've updated CHANGES.md with what I changed.
- [x] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column