### PR TITLE
Ensured scroll bars are shown on Chrome/Webkit except on search facets

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -42,6 +42,7 @@
 *   Add 3 more government CSW services
 *   Hide feedback form from mobile view
 *   Upgraded React and associates to v16.3
+*   Ensured scroll bars are shown on Chrome/Webkit except on search facet autocomplete lists
 
 ## 0.0.37
 

--- a/magda-web-client/src/Components/SearchFacets/FacetHeader.scss
+++ b/magda-web-client/src/Components/SearchFacets/FacetHeader.scss
@@ -13,9 +13,10 @@
         padding: 4px;
         display: flex;
     }
-
-    .btn-facet {
-        width: 100%;
+    @media (max-width: $medium) {
+        .btn-facet {
+            width: 100%;
+        }
     }
     button {
         border: 1px solid rgba(73, 73, 73, 0.05);

--- a/magda-web-client/src/Components/SearchFacets/SearchFacets.scss
+++ b/magda-web-client/src/Components/SearchFacets/SearchFacets.scss
@@ -71,7 +71,10 @@
         height: 45px;
     }
 }
-
+.react-autosuggest__suggestions-container::-webkit-scrollbar {
+    -webkit-appearance: none;
+    width: 8px;
+}
 .facet-body {
     margin-top: 8px;
     box-shadow: 0 3px 6px 0 rgba(0, 0, 0, 0.23), 0 3px 6px 0 rgba(0, 0, 0, 0.16);
@@ -79,6 +82,7 @@
     border-radius: 2px;
     z-index: 1;
     padding: 0 16px;
+
     @media (max-width: $medium) {
         position: fixed;
         left: 5px;
@@ -110,15 +114,7 @@
         overflow-y: auto;
         -webkit-overflow-scrolling: touch;
     }
-    ::-webkit-scrollbar {
-        -webkit-appearance: none;
-        width: 8px;
-    }
-}
 
-::-webkit-scrollbar {
-    -webkit-appearance: none;
-    width: 8px;
 }
 
 .btn-facet-option {


### PR DESCRIPTION
### What this PR does
Ensured scroll bars are shown on Chrome/Webkit except on search facet autocomplete lists



### Checklist
- [x] Unit tests aren't applicable 
- [x] I've updated CHANGES.md with what I changed.
- [x] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column