### PR TITLE
Issue/737: Users cannot search current search text by clicking search button or pressing enter key

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -43,6 +43,7 @@
 *   Hide feedback form from mobile view
 *   Upgraded React and associates to v16.3
 *   Ensured scroll bars are shown on Chrome/Webkit except on search facet autocomplete lists
+*   Fixed an issue that prevents users from searching current search text by clicking search button or pressing enter key
 
 ## 0.0.37
 

--- a/magda-web-client/src/Components/Search/SearchBox.js
+++ b/magda-web-client/src/Components/Search/SearchBox.js
@@ -84,6 +84,7 @@ class SearchBox extends Component {
         // when user hit enter, no need to submit the form
         if (event.charCode === 13) {
             event.preventDefault();
+            this.debounceUpdateSearchQuery(this.getSearchBoxValue());
             this.debounceUpdateSearchQuery.flush();
         }
     }
@@ -92,6 +93,7 @@ class SearchBox extends Component {
      * If the search button is clicked, we do the search immediately
      */
     onClickSearch() {
+        this.debounceUpdateSearchQuery(this.getSearchBoxValue());
         this.debounceUpdateSearchQuery.flush();
     }
 


### PR DESCRIPTION
### What this PR does

Fixed an issue that prevents users from searching current search text by clicking search button or pressing enter key (on dataset page)

### Checklist
- [ ] Unit tests aren't applicable (delete one)
- [ ] I've updated CHANGES.md with what I changed.
- [ ] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column