### PR TITLE
Issue/831 keep distance between search box and the first story on mobile view

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -45,6 +45,7 @@
 *   Upgraded React and associates to v16.3
 *   Ensured scroll bars are shown on Chrome/Webkit except on search facet autocomplete lists
 *   Fixed an issue that prevents users from searching current search text by clicking search button or pressing enter key
+*   keep distance between search box and the first story on mobile view
 
 ## 0.0.37
 

--- a/magda-web-client/src/Pages/HomePageComponents/Stories.scss
+++ b/magda-web-client/src/Pages/HomePageComponents/Stories.scss
@@ -1,6 +1,10 @@
 @import "../../variables";
 
 .homepage-stories {
+    @media (max-width: $medium) {
+        margin-top: 16px;
+    }
+
     .stories-container {
         display: flex;
         justify-content: space-between;


### PR DESCRIPTION
### What this PR does

keep distance between the search box and the first story on mobile view


### Checklist
- [x] Unit tests aren't applicable
- [x] I've updated CHANGES.md with what I changed.
- [x] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column