### PR TITLE
Made data quality consistent between search and details

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -49,6 +49,7 @@
 *   Fixed an issue that prevents users from searching current search text by clicking search button or pressing enter key
 *   keep distance between search box and the first story on mobile view
 *   Moved homepage config from S3 to local
+*   Made data quality rating use stars across search results and quality page, and made both use quality aspect.
 
 ## 0.0.37
 

--- a/magda-web-client/package-lock.json
+++ b/magda-web-client/package-lock.json
@@ -18340,7 +18340,7 @@
             "version": "github:TerriaJS/draft-js-mention-plugin#e180d44a84ce7d9497ec2248783b9d0bb2712a8a",
             "requires": {
                 "decorate-component-with-props": "1.1.0",
-                "find-with-regex": "1.0.2",
+                "find-with-regex": "1.1.2",
                 "lodash.escaperegexp": "4.1.2",
                 "union-class-names": "1.0.0"
             },
@@ -18351,9 +18351,9 @@
                     "integrity": "sha512-tTYQojixN64yK3/WBODMfvss/zbmyUx9HQXhzSxZiSiofeekVeRyyuToy9BCiTMrVEIKWxTcla2t3y5qdaUF7Q=="
                 },
                 "find-with-regex": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/find-with-regex/-/find-with-regex-1.0.2.tgz",
-                    "integrity": "sha1-07NihlOfFMUn4x8ZQVnG0lFlGkU="
+                    "version": "1.1.2",
+                    "resolved": "https://registry.npmjs.org/find-with-regex/-/find-with-regex-1.1.2.tgz",
+                    "integrity": "sha512-i92JpVvGMqCtgu46bX1DwJ3trymcGtnlxDxjk3SVBNxm9wPmt8/A5Vzs51Pek5BBpmXwF4pE07buqt+aHYWz4A=="
                 },
                 "lodash.escaperegexp": {
                     "version": "4.1.2",
@@ -35175,6 +35175,11 @@
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
             "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg=="
+        },
+        "weighted-mean": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/weighted-mean/-/weighted-mean-1.0.2.tgz",
+            "integrity": "sha1-o+KsNl9zwjt9midoagCXeUs1pVA="
         },
         "whatwg-encoding": {
             "version": "1.0.3",

--- a/magda-web-client/package.json
+++ b/magda-web-client/package.json
@@ -111,6 +111,7 @@
     "uuid": "^3.0.1",
     "vega": "^3.0.0-rc2",
     "vega-lite": "^2.0.0-beta.8",
+    "weighted-mean": "^1.0.2",
     "yaml-front-matter": "^4.0.0"
   },
   "proxy": {

--- a/magda-web-client/src/Components/Dataset/DatasetDetails.js
+++ b/magda-web-client/src/Components/Dataset/DatasetDetails.js
@@ -10,7 +10,6 @@ import DistributionRow from "../DistributionRow";
 import queryString from "query-string";
 import "./RecordDetails.css";
 import "./DatasetDetails.css";
-import { Link } from "react-router-dom";
 import { Small, Medium } from "../../UI/Responsive";
 
 class DatasetDetails extends Component {

--- a/magda-web-client/src/Components/Dataset/DatasetDetails.js
+++ b/magda-web-client/src/Components/Dataset/DatasetDetails.js
@@ -3,7 +3,7 @@ import TemporalAspectViewer from "../../UI/TemporalAspectViewer";
 import DatasetPreview from "./DatasetPreview";
 import DescriptionBox from "../../UI/DescriptionBox";
 import MarkdownViewer from "../../UI/MarkdownViewer";
-import StarRating from "../../UI/StarRating";
+import QualityIndicator from "../../UI/QualityIndicator";
 import TagsBox from "../../UI/TagsBox";
 import { connect } from "react-redux";
 import DistributionRow from "../DistributionRow";
@@ -42,9 +42,7 @@ class DatasetDetails extends Component {
                     </Medium>
                 </div>
                 <div className="quality-rating-box">
-                    <Link to="/page/dataset-quality">Open Data Quality</Link>:
-                    &nbsp;&nbsp;
-                    <StarRating stars={dataset.linkedDataRating} />
+                    <QualityIndicator quality={dataset.linkedDataRating} />
                 </div>
                 <TagsBox tags={dataset.tags} />
                 <div className="dataset-preview">

--- a/magda-web-client/src/Components/Dataset/DatasetDetails.scss
+++ b/magda-web-client/src/Components/Dataset/DatasetDetails.scss
@@ -57,22 +57,10 @@
         opacity: 0.75;
     }
 }
-
-.quality-rating-box {
-    margin-top: 20px;
-    margin-bottom: 20px;
-    position: relative;
-    span {
-        color: #535353;
-        font-size: 14px;
-        line-height: 16px;
-    }
-    .star-rating-box {
-        position: absolute;
-        top: 5px;
-    }
-}
-
 .dataset-details-files-apis {
     margin-top: 50px;
+}
+
+.quality-rating-box {
+    margin: 20px 0;
 }

--- a/magda-web-client/src/UI/QualityIndicator.js
+++ b/magda-web-client/src/UI/QualityIndicator.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { Link } from "react-router-dom";
 
+import StarRating from "./StarRating";
 import "./QualityIndicator.css";
 import helpIcon from "../assets/help-24.svg";
 
@@ -11,34 +12,11 @@ function QualityIndicator(props) {
         rating = 0;
     }
 
-    const qualities = [
-        ["Poor", "#c0392b"],
-        ["OK", "#FE7F7F"],
-        ["Average", "#9b59b6"],
-        ["Good", "#3498db"],
-        ["Excellent", "#12C9A0"]
-    ];
-
-    function getBarColor(index) {
-        return {
-            display: "inline-block",
-            height: "11px",
-            width: "4px",
-            marginRight: "2px",
-            backgroundColor: qualities[rating][1],
-            opacity: rating >= index ? 1 : 0.5
-        };
-    }
-
     return (
         <div>
-            {" "}
-            Open Data Quality: {qualities[rating][0]}{" "}
-            <span>
-                {qualities.map((q, i) => (
-                    <span key={i} style={getBarColor(i)} />
-                ))}
-            </span>&nbsp;
+            <Link to="/page/dataset-quality">Open Data Quality</Link>:
+            &nbsp;&nbsp;
+            <StarRating stars={rating} />
             <div className="tooltip">
                 <img src={helpIcon} alt="Help Link" />
                 <span className="tooltiptext">

--- a/magda-web-client/src/UI/QualityIndicator.scss
+++ b/magda-web-client/src/UI/QualityIndicator.scss
@@ -1,11 +1,10 @@
 .tooltip {
     position: relative;
     display: inline-block;
-    // border-bottom: 1px dotted black;
+    margin-left: 5px;
 }
 
 .tooltip .tooltiptext {
-    //cursor: pointer;
     visibility: hidden;
     width: 258px;
     background-color: white;
@@ -45,4 +44,8 @@
 .tooltiptext {
     transition-delay: 1s;
     transition: all 1s ease;
+}
+
+.star-rating-box {
+    vertical-align: sub;
 }

--- a/magda-web-client/src/actions/recordActions.js
+++ b/magda-web-client/src/actions/recordActions.js
@@ -55,7 +55,7 @@ export function fetchDatasetFromRegistry(id: string): Function {
             config.registryApiUrl +
             `records/${encodeURIComponent(
                 id
-            )}?aspect=dcat-dataset-strings&optionalAspect=dcat-distribution-strings&optionalAspect=dataset-distributions&optionalAspect=temporal-coverage&dereference=true&optionalAspect=dataset-publisher&optionalAspect=source&optionalAspect=link-status&optionalAspect=dataset-linked-data-rating`;
+            )}?aspect=dcat-dataset-strings&optionalAspect=dcat-distribution-strings&optionalAspect=dataset-distributions&optionalAspect=temporal-coverage&dereference=true&optionalAspect=dataset-publisher&optionalAspect=source&optionalAspect=link-status&optionalAspect=dataset-quality-rating`;
         return fetch(url)
             .then(response => {
                 if (response.status === 200) {

--- a/magda-web-client/src/helpers/record.js
+++ b/magda-web-client/src/helpers/record.js
@@ -1,6 +1,7 @@
 // @flow
 import getDateString from "./getDateString";
 import type { FetchError } from "../types";
+import weightedMean from "weighted-mean";
 // dataset query:
 //aspect=dcat-dataset-strings&optionalAspect=dcat-distribution-strings&optionalAspect=dataset-distributions&optionalAspect=temporal-coverage&dereference=true&optionalAspect=dataset-publisher&optionalAspect=source
 
@@ -275,8 +276,15 @@ export function parseDataset(dataset?: RawDataset): ParsedDataset {
         ? aspects["source"]["name"]
         : defaultDatasetAspects["source"]["name"];
 
-    const linkedDataRating: number = aspects["dataset-linked-data-rating"]
-        ? aspects["dataset-linked-data-rating"]["stars"]
+    function calcQuality(qualityAspect) {
+        const ratings = Object.keys(qualityAspect)
+            .map(key => qualityAspect[key])
+            .map(aspectRating => [aspectRating.score, aspectRating.weighting]);
+        return weightedMean(ratings);
+    }
+
+    const linkedDataRating: number = aspects["dataset-quality-rating"]
+        ? calcQuality(aspects["dataset-quality-rating"])
         : 0;
 
     const distributions = distribution["distributions"].map(d => {


### PR DESCRIPTION
### What this PR does
- Makes the search page quality rating have the same appearance as the dataset page (⭐️⭐️⭐️).
- Makes the dataset page use the same data as the search (weighted mean of quality aspect) so they're consistent. This will mean they're slightly inflated until #819 lands.

### Checklist
- [x] Unit tests aren't applicable
- [x] I've updated CHANGES.md with what I changed.
- [x] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column