### PR TITLE
Added stub correspondence service

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 *   Use colours from DTA design guide
 *   Fixed distribution previews
+*   Added stubbed correspondence api
 
 ## 0.0.38
 

--- a/deploy/helm/magda/charts/correspondence-api/Chart.yaml
+++ b/deploy/helm/magda/charts/correspondence-api/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: A Helm chart for Kubernetes
+name: correspondence-api
+version: 0.1.0

--- a/deploy/helm/magda/charts/correspondence-api/templates/deployment.yaml
+++ b/deploy/helm/magda/charts/correspondence-api/templates/deployment.yaml
@@ -1,0 +1,40 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: correspondence-api
+spec:
+  replicas: {{ .Values.replicas | default 1 }}
+  strategy:
+    rollingUpdate:
+      maxUnavailable: {{ .Values.global.rollingUpdate.maxUnavailable | default 0 }}
+  template:
+    metadata:
+      labels:
+        service: correspondence-api
+    spec:
+      containers:
+      - name: correspondence-api
+        image: {{ template "dockerimage" . }}
+        imagePullPolicy: {{ .Values.image.pullPolicy | default .Values.global.image.pullPolicy }}
+        command: [
+            "node",
+            "/usr/src/app/component/dist/index.js",
+            "--listenPort", "80",
+        ]
+        livenessProbe:
+          httpGet:
+            path: /v0/healthz
+            port: 80
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 10
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+        env:
+        - name: NODE_ENV
+          value: production
+        - name: JWT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: auth-secrets
+              key: jwt-secret

--- a/deploy/helm/magda/charts/correspondence-api/templates/service.yaml
+++ b/deploy/helm/magda/charts/correspondence-api/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: correspondence-api
+spec:
+  ports:
+  - name: http
+    port: 80
+    targetPort: 80
+{{- if .Values.global.exposeNodePorts }}
+    nodePort: 30117
+  type: NodePort
+{{- end }}
+  selector:
+    service: correspondence-api

--- a/deploy/helm/magda/charts/correspondence-api/values.yaml
+++ b/deploy/helm/magda/charts/correspondence-api/values.yaml
@@ -1,0 +1,16 @@
+image: {}
+  #repository: data61/
+  #tag: latest
+  # pullPolicy: Always
+gitHubIssuesUrl:
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi

--- a/deploy/helm/magda/charts/gateway/templates/configmap.yaml
+++ b/deploy/helm/magda/charts/gateway/templates/configmap.yaml
@@ -29,5 +29,8 @@ data:
     },
     "feedback": {
         "to": "http://feedback-api/v0"
+    },
+    "correspondence": {
+        "to": "http://correspondence-api/v0/public"
     }
   }'

--- a/deploy/helm/magda/requirements.yaml
+++ b/deploy/helm/magda/requirements.yaml
@@ -95,3 +95,9 @@ dependencies:
     tags:
       - all
       - web-server
+  - name: correspondence-api
+    version: 0.1.0
+    tags:
+      - all
+      - correspondence-api
+

--- a/doc/local-ports.md
+++ b/doc/local-ports.md
@@ -22,3 +22,5 @@ It is not necessary to allocate ports to microservices when running on a Kuberne
 | `magda-ckan-connector`              | 6113 |
 | `magda-web-admin`                   | 6114 |
 | `magda-sleuther-format`             | 6115 |
+| `magda-feedback`                    | 6116 |
+| `magda-correspondence-api`          | 6117 |

--- a/magda-correspondence-api/Dockerfile
+++ b/magda-correspondence-api/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:6
+
+RUN mkdir -p /usr/src/app
+COPY . /usr/src/app
+WORKDIR /usr/src/app/component
+ENTRYPOINT [ "node", "/usr/src/app/component/dist/index.js" ]

--- a/magda-correspondence-api/package.json
+++ b/magda-correspondence-api/package.json
@@ -1,0 +1,35 @@
+{
+    "name": "@magda/correspondence-api",
+    "description": "MAGDA correspondence API",
+    "version": "0.0.39-0",
+    "license": "Apache-2.0",
+    "scripts": {
+        "build": "npm run compile",
+        "compile": "tsc -p tsconfig-build.json",
+        "watch": "tsc -p tsconfig-build.json --watch",
+        "start": "node dist/index.js",
+        "dev": "run-typescript-in-nodemon src/index.ts",
+        "docker-build-local": "create-docker-context-for-node-component --build --push --tag auto --local",
+        "docker-build-prod": "create-docker-context-for-node-component --build --push --tag auto"
+    },
+    "dependencies": {
+        "@magda/typescript-common": "^0.0.39-0",
+        "body-parser": "^1.13.2",
+        "express": "^4.13.1",
+        "isomorphic-fetch": "^2.2.1",
+        "yargs": "^8.0.2"
+    },
+    "devDependencies": {
+        "@magda/scripts": "^0.0.39-0",
+        "@types/express": "^4.0.35",
+        "@types/node": "^8.0.14",
+        "@types/yargs": "^8.0.2",
+        "typescript": "~2.5.0"
+    },
+    "config": {
+        "docker": {
+            "name": "data61/magda-correspondence-api",
+            "include": "node_modules dist Dockerfile"
+        }
+    }
+}

--- a/magda-correspondence-api/src/createApiRouter.ts
+++ b/magda-correspondence-api/src/createApiRouter.ts
@@ -1,0 +1,55 @@
+import * as express from "express";
+import { Router } from "express";
+import { DatasetMessage } from "./model";
+
+export interface ApiRouterOptions {
+    jwtSecret: string;
+}
+
+export default function createApiRouter(options: ApiRouterOptions) {
+    const router: Router = express.Router();
+
+    router.get("/healthz", (req, res) => res.status(200).send("OK"));
+
+    function handleDatasetMessage(req: express.Request, res: express.Response) {
+        setTimeout(() => {
+            const body = req.body as DatasetMessage;
+
+            const randomFloat = Math.random();
+
+            try {
+                if (!body.message || !body.senderEmail || !body.senderName) {
+                    return res.status(400).send({
+                        status: "Failure",
+                        error: "Missing input"
+                    });
+                }
+
+                if (randomFloat > 0.1) {
+                    // 1 in 10 chance of failing
+                    return res.status(200).send({
+                        status: "success"
+                    });
+                } else {
+                    throw Error("Randomly generated error for fun");
+                }
+            } catch (e) {
+                return res.status(500).send({
+                    status: "failure",
+                    error: e.message
+                });
+            }
+        }, 1000);
+    }
+
+    router.post("/public/send/dataset/request", handleDatasetMessage);
+
+    router.post(
+        "/public/send/dataset/:datasetId/question",
+        handleDatasetMessage
+    );
+
+    router.post("/public/send/dataset/:datasetId/report", handleDatasetMessage);
+
+    return router;
+}

--- a/magda-correspondence-api/src/index.ts
+++ b/magda-correspondence-api/src/index.ts
@@ -1,0 +1,40 @@
+import * as express from "express";
+import * as yargs from "yargs";
+
+import addJwtSecretFromEnvVar from "@magda/typescript-common/dist/session/addJwtSecretFromEnvVar";
+
+import createApiRouter from "./createApiRouter";
+
+const argv = addJwtSecretFromEnvVar(
+    yargs
+        .config()
+        .help()
+        .option("listenPort", {
+            describe:
+                "The TCP/IP port on which the authorization-api should listen.",
+            type: "number",
+            default: 6117
+        })
+        .option("jwtSecret", {
+            describe: "The shared secret for intra-network communication",
+            type: "string"
+        }).argv
+);
+
+const app = express();
+app.use(require("body-parser").json());
+
+app.use(
+    "/v0",
+    createApiRouter({
+        jwtSecret: argv.jwtSecret
+    })
+);
+
+const listenPort = argv.listenPort;
+app.listen(listenPort);
+console.log("Listening on " + listenPort);
+
+process.on("unhandledRejection", (reason: string, promise: any) => {
+    console.error(reason);
+});

--- a/magda-correspondence-api/src/model.ts
+++ b/magda-correspondence-api/src/model.ts
@@ -1,0 +1,5 @@
+export interface DatasetMessage {
+    senderName: String;
+    senderEmail: String;
+    message: String;
+}

--- a/magda-correspondence-api/tsconfig-build.json
+++ b/magda-correspondence-api/tsconfig-build.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../tsconfig-global.json",
+    "compilerOptions": {
+        "declaration": true,
+        "outDir": "dist",
+        "baseUrl": "."
+    },
+    "include": ["src"]
+}

--- a/magda-correspondence-api/tsconfig.json
+++ b/magda-correspondence-api/tsconfig.json
@@ -1,0 +1,14 @@
+{
+    "extends": "./tsconfig-build.json",
+    "compilerOptions": {
+        "baseUrl": ".",
+        "paths": {
+            "@magda/authorization-api/dist/*": [
+                "./node_modules/@magda/authorization-api/src/*"
+            ],
+            "@magda/typescript-common/dist/*": [
+                "./node_modules/@magda/typescript-common/src/*"
+            ]
+        }
+    }
+}


### PR DESCRIPTION
### What this PR does
Adds `magda-correspondence-api`.

This adds endpoints for sending correspondence. Three are available through the gateway at `/api/v0/correspondence`: 
    - `correspondence/send/dataset/:datasetId/report` for reporting a problem with a dataset
    - `correspondence/send/dataset/:datasetId/question` for reporting a question for a dataset
    - `correspondence/send/dataset/request` for requesting a dataset.
All these endpoints expect a `POST` with JSON in the format:
```
{
	"message": "blah",
	"senderEmail": "blah",
	"senderName": "Blah"
}
```

### Checklist
- [x] Unit tests aren't applicable (this is a stub)
- [x] I've updated CHANGES.md with what I changed.
- [x] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column