### PR TITLE
Made GA post to terria GA as well again.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,7 @@
 *   Chart is available for Non-time series CSV data files now
 *   Map preview on `nationalmap` will be processed by `MagdaCatalogItem`
 *   Switched to using yarn as the package manager
+*   Made frontend GA post to both terria and dga google analytics.
 
 ## 0.0.38
 

--- a/magda-web-client/src/Components/Dataset/DistributionDetails.js
+++ b/magda-web-client/src/Components/Dataset/DistributionDetails.js
@@ -2,6 +2,7 @@ import React, { Component } from "react";
 import { connect } from "react-redux";
 import TemporalAspectViewer from "../../UI/TemporalAspectViewer";
 import OverviewBox from "../../UI/OverviewBox";
+import ga from "../../analytics/googleAnalytics";
 import "./RecordDetails.css";
 
 class DistributionDetails extends Component {
@@ -22,8 +23,8 @@ class DistributionDetails extends Component {
                         const resource_url = encodeURIComponent(
                             distribution.downloadURL
                         );
-                        if (resource_url && window.ga) {
-                            window.ga("send", {
+                        if (resource_url) {
+                            ga("send", {
                                 hitType: "event",
                                 eventCategory: "Resource",
                                 eventAction: "Download",

--- a/magda-web-client/src/Components/DistributionRow.js
+++ b/magda-web-client/src/Components/DistributionRow.js
@@ -9,6 +9,7 @@ import defaultFormatIcon from "../assets/format-passive-dark.svg";
 import downloadIcon from "../assets/download.svg";
 import newTabIcon from "../assets/external.svg";
 import { Medium } from "../UI/Responsive";
+import ga from "../analytics/googleAnalytics";
 import ReactTooltip from "react-tooltip";
 const formatIcons = {
     default: defaultFormatIcon
@@ -209,8 +210,8 @@ class DistributionRow extends Component {
                                 const resource_url = encodeURIComponent(
                                     distribution.downloadURL
                                 );
-                                if (resource_url && window.ga) {
-                                    window.ga("send", {
+                                if (resource_url) {
+                                    ga("send", {
                                         hitType: "event",
                                         eventCategory: "Resource",
                                         eventAction: "Download",

--- a/magda-web-client/src/analytics/googleAnalytics.js
+++ b/magda-web-client/src/analytics/googleAnalytics.js
@@ -1,0 +1,14 @@
+/**
+ * Call Google Analytics such that any calls go to both terria tracker and data.gov.au tracker.
+ */
+export default function ga(...args) {
+    if (typeof window !== "undefined" && window.ga) {
+        // Clone a terria version of the args
+        var terriaArgs = args.concat();
+
+        terriaArgs[0] = "terria." + terriaArgs[0];
+
+        window.ga(...args);
+        window.ga(...terriaArgs);
+    }
+}

--- a/magda-web-client/src/index.js
+++ b/magda-web-client/src/index.js
@@ -14,6 +14,7 @@ import { createStore, applyMiddleware } from "redux";
 import AppContainer from "./AppContainer";
 import PropTypes from "prop-types";
 import ScrollToTop from "./helpers/ScrollToTop";
+import ga from "./analytics/googleAnalytics";
 
 const store = createStore(
     reducer,
@@ -34,10 +35,8 @@ class GAListener extends React.Component {
     }
 
     sendPageView(location) {
-        if (window.ga) {
-            window.ga("set", "location", location.pathname);
-            window.ga("send", "pageview");
-        }
+        ga("set", "location", location.pathname);
+        ga("send", "pageview");
     }
 
     render() {


### PR DESCRIPTION
### What this PR does
Recently we gave the terria ga a name, which meant that the data.gov.au GA became the default and the terria ga stopped receiving events.

According to this https://developers.google.com/analytics/devguides/collection/analyticsjs/creating-trackers if we give a tracker a name we've got to prefix every call with that tracker's name in order to send to it.

So this wraps a function around `window.ga` that makes it perform the function for the unprefixed GA (data.gov.au) and the prefixed one (terria).

This can be tested by looking at devtools in the browser - when you go to a new page you should be able to see two calls to www.google-analytics.com/collect, one with the terria UA (UA-92539508-1) and one with a different UA for data.gov.au.

![image](https://user-images.githubusercontent.com/900555/39791366-9bb4ea22-537e-11e8-9ed1-be7e7e76fdd3.png)

### Checklist
- [x] Unit tests aren't applicable 
- [x] I've updated CHANGES.md with what I changed.
- [x] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column