### PR TITLE
Tagged the correspondence api as a typescript api.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,7 @@
 *   Fixed the GAP under preview map loading box
 *   Switched to using yarn as the package manager
 *   Made frontend GA post to both terria and dga google analytics.
+*   Tagged correspondence api as a typescript api.
 
 ## 0.0.38
 

--- a/magda-correspondence-api/package.json
+++ b/magda-correspondence-api/package.json
@@ -33,5 +33,11 @@
             "name": "data61/magda-correspondence-api",
             "include": "node_modules dist Dockerfile"
         }
+    },
+    "magda": {
+        "language": "typescript",
+        "categories": {
+            "api": true
+        }
     }
 }


### PR DESCRIPTION
### What this PR does
The correspondence api was never tagged as an api, which means `yarn run in-modules` doesn't pick it up, and it breaks on the auto deploy to master. This fixes that.


### Checklist
- [x] Unit tests aren't applicable (delete one)
- [x] I've updated CHANGES.md with what I changed.
- [x] No issue