### PR TITLE
Fixed up docker script to support multiple versions of same yarn pkg

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,7 @@
 *   Switched to using yarn as the package manager
 *   Made frontend GA post to both terria and dga google analytics.
 *   Tagged correspondence api as a typescript api.
+*   Fixed up docker scripts to make them handle multiple versions of yarn packages coexisting.
 
 ## 0.0.38
 

--- a/magda-preview-map/Dockerfile
+++ b/magda-preview-map/Dockerfile
@@ -3,4 +3,4 @@ FROM node:6
 RUN mkdir -p /usr/src/app
 COPY . /usr/src/app
 WORKDIR /usr/src/app/component
-ENTRYPOINT [ "node", "./node_modules/terriajs-server/lib/app.js", "--config-file", "devserverconfig.json" ]
+ENTRYPOINT [ "node", "../node_modules/terriajs-server/lib/app.js", "--config-file", "devserverconfig.json" ]


### PR DESCRIPTION
### What this PR does
When I changed the docker scripts that bundle node packages into the images, I had a very naive view of yarn's dependency resolution - they just put everything they could find into the root `node_modules` in the image. Unfortunately if you have multiple versions of the same package anywhere in magda (which we do, obviously) this falls apart... in particular all the sleuthers and the preview-map currently fail because they can't find a submodule of one of their dependencies, which is a much older dependency than the one that's getting bundled into the image.

This makes the scripts actually look at the individual children of each npm module and makes it put it into the node_modules of that package if required, instead of assuming that all packages are declared at the root of `yarn list` and should be present at the root of `node_modules`.


### Checklist
- [x] Unit tests aren't applicable (delete one)
- [x] I've updated CHANGES.md with what I changed.
- [x] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column