### PR TITLE
Made master-> dev step deploy connectors too

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -62,7 +62,7 @@ generate-connector-jobs:
   cache: {}
   script:
     - cd deploy
-    - yarn run generate-connector-jobs-dev
+    - yarn run generate-connector-jobs --prod true --in ./connector-config --out ./kubernetes/generated/prod --imageVersion=$CI_COMMIT_REF_SLUG
     - mkdir kubernetes/generated/prod/cron
     - mv kubernetes/generated/prod/*-cron.json kubernetes/generated/prod/cron
   artifacts:
@@ -474,7 +474,6 @@ deploy-master-to-dev:
     name: dev
     url: https://magda-dev.terria.io
   script:
-  # Kube Config
   - echo "$KUBECTL_CONFIG" > kubectlconfig.yaml
   - export KUBECONFIG=kubectlconfig.yaml
   - kubectl create secret docker-registry regcred --namespace default --docker-server=registry.gitlab.com --docker-username=gitlab-ci-token --docker-password=$CI_JOB_TOKEN --docker-email=alex.gilleran@data61.csiro.au --dry-run -o json | kubectl apply --namespace default -f -

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,6 +56,21 @@ registry-typescript-api:
       - "magda-typescript-common/src/generated"
     expire_in: 30 days
 
+generate-connector-jobs:
+  stage: prebuild
+  image: registry.gitlab.com/magda-data/magda/data61/magda-builder-nodejs:$CI_COMMIT_REF_SLUG
+  cache: {}
+  script:
+    - cd deploy
+    - yarn run generate-connector-jobs-dev
+    - mkdir kubernetes/generated/prod/cron
+    - mv kubernetes/generated/prod/*-cron.json kubernetes/generated/prod/cron
+  artifacts:
+    paths:
+      - "deploy/kubernetes/generated"
+    expire_in: 30 days
+
+
 buildtest:search-with-index-cache:
   stage: buildtest
   image: registry.gitlab.com/magda-data/magda/data61/magda-builder-scala:$CI_COMMIT_REF_SLUG
@@ -447,8 +462,9 @@ Stop Preview:
 deploy-master-to-dev:
   stage: deploy-dev
   only:
-    - master
-  dependencies: []
+    - branches
+  dependencies:
+    - generate-connector-jobs
   cache: 
     paths: []
   image: 
@@ -456,10 +472,12 @@ deploy-master-to-dev:
   before_script: []
   environment:
     name: dev
-    url: http://magda-dev.terria.io
+    url: https://magda-dev.terria.io
   script:
   # Kube Config
   - echo "$KUBECTL_CONFIG" > kubectlconfig.yaml
   - export KUBECONFIG=kubectlconfig.yaml
   - kubectl create secret docker-registry regcred --namespace default --docker-server=registry.gitlab.com --docker-username=gitlab-ci-token --docker-password=$CI_JOB_TOKEN --docker-email=alex.gilleran@data61.csiro.au --dry-run -o json | kubectl apply --namespace default -f -
   - helm upgrade magda deploy/helm/magda --install --recreate-pods -f deploy/helm/magda-dev.yml --set global.image.repository=registry.gitlab.com/magda-data/magda/data61,global.image.tag=master --timeout 1200 --wait
+  - kubectl delete configmap connector-config --ignore-not-found && kubectl create configmap connector-config --from-file deploy/connector-config/
+  - kubectl apply -f deploy/kubernetes/generated/prod/cron

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -462,7 +462,7 @@ Stop Preview:
 deploy-master-to-dev:
   stage: deploy-dev
   only:
-    - branches
+    - master
   dependencies:
     - generate-connector-jobs
   cache: 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -62,7 +62,7 @@ generate-connector-jobs:
   cache: {}
   script:
     - cd deploy
-    - yarn run generate-connector-jobs --prod true --in ./connector-config --out ./kubernetes/generated/prod --imageVersion=$CI_COMMIT_REF_SLUG
+    - yarn run generate-connector-jobs --prod true --in ./connector-config --out ./kubernetes/generated/prod --imageVersion=$CI_COMMIT_REF_SLUG --imagePrefix=registry.gitlab.com/magda-data/magda/data61/
     - mkdir kubernetes/generated/prod/cron
     - mv kubernetes/generated/prod/*-cron.json kubernetes/generated/prod/cron
   artifacts:
@@ -464,7 +464,7 @@ Stop Preview:
 deploy-master-to-dev:
   stage: deploy-dev
   only:
-    - master
+    - branches
   dependencies:
     - generate-connector-jobs
   cache: {}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -464,7 +464,7 @@ Stop Preview:
 deploy-master-to-dev:
   stage: deploy-dev
   only:
-    - branches
+    - master
   dependencies:
     - generate-connector-jobs
   cache: {}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,7 @@
 *   Switched to using yarn as the package manager
 *   Made frontend GA post to both terria and dga google analytics.
 *   Tagged correspondence api as a typescript api.
+*   Made auto deploy for master -> dev server reconfigure jobs.
 
 ## 0.0.38
 

--- a/deploy/package.json
+++ b/deploy/package.json
@@ -3,11 +3,17 @@
     "version": "0.0.39-0",
     "description": "MAGDA deployment configuration.",
     "scripts": {
-        "create-connector-configmap": "kubectl delete configmap connector-config --ignore-not-found && kubectl create configmap connector-config --from-file ./connector-config/",
-        "generate-connector-jobs-local": "generate-connector-jobs --in ./connector-config --out ./kubernetes/generated/local --local",
-        "generate-connector-jobs-dev": "generate-connector-jobs --prod true --in ./connector-config --out ./kubernetes/generated/prod",
-        "generate-connector-jobs-prod": "generate-connector-jobs --prod true --in ./connector-config --out ./kubernetes/generated/prod",
-        "create-config-configmap": "kubectl delete configmap config --ignore-not-found && kubectl create configmap config --from-file ./kubernetes/config/"
+        "create-connector-configmap":
+            "kubectl delete configmap connector-config --ignore-not-found && kubectl create configmap connector-config --from-file ./connector-config/",
+        "generate-connector-jobs": "generate-connector-jobs",
+        "generate-connector-jobs-local":
+            "generate-connector-jobs --in ./connector-config --out ./kubernetes/generated/local --local",
+        "generate-connector-jobs-dev":
+            "generate-connector-jobs --prod true --in ./connector-config --out ./kubernetes/generated/prod",
+        "generate-connector-jobs-prod":
+            "generate-connector-jobs --prod true --in ./connector-config --out ./kubernetes/generated/prod",
+        "create-config-configmap":
+            "kubectl delete configmap config --ignore-not-found && kubectl create configmap config --from-file ./kubernetes/config/"
     },
     "author": "",
     "license": "Apache-2.0",
@@ -20,7 +26,8 @@
     },
     "bin": {
         "generate-registry-typescript": "generate-registry-typescript.js",
-        "create-docker-context-for-node-component": "create-docker-context-for-node-component.js",
+        "create-docker-context-for-node-component":
+            "create-docker-context-for-node-component.js",
         "generate-connector-jobs": "generate-connector-jobs.js"
     }
 }

--- a/scripts/generate-connector-jobs.js
+++ b/scripts/generate-connector-jobs.js
@@ -30,6 +30,11 @@ const argv = yargs
             "Whether to use values appropriate for a dev cluster or a prod cluster",
         type: "boolean",
         default: false
+    })
+    .option("imageVersion", {
+        describe:
+            "Overrides the version of the image that will be given to the jobs. Defaults to 'latest' if 'local' is specified, otherwise it will match the version of this package.",
+        type: "string"
     }).argv;
 
 fs.ensureDirSync(argv.out);
@@ -45,9 +50,18 @@ files.forEach(function(connectorConfigFile) {
         fs.readFileSync(path.join(connectorPackagePath, "package.json"), "utf8")
     );
 
+    function getImageVersion() {
+        if (argv.imageVersion) {
+            return argv.imageVersion;
+        } else if (argv.local) {
+            return "latest";
+        } else {
+            return connectorPackageJson.version;
+        }
+    }
+
     const imagePrefix = argv.local ? "localhost:5000/data61/" : "data61/";
-    const imageVersion = argv.local ? "latest" : connectorPackageJson.version;
-    const image = imagePrefix + configFile.type + ":" + imageVersion;
+    const image = imagePrefix + configFile.type + ":" + getImageVersion();
     const prod = argv.prod;
 
     const basename = path.basename(connectorConfigFile.path, ".json");

--- a/scripts/generate-connector-jobs.js
+++ b/scripts/generate-connector-jobs.js
@@ -35,6 +35,11 @@ const argv = yargs
         describe:
             "Overrides the version of the image that will be given to the jobs. Defaults to 'latest' if 'local' is specified, otherwise it will match the version of this package.",
         type: "string"
+    })
+    .option("imagePrefix", {
+        describe:
+            "Overrides the prefix for the image that will be given to the jobs. Defaults to 'localhost:5000/data61' if 'local' is specified, otherwise data61/",
+        type: "string"
     }).argv;
 
 fs.ensureDirSync(argv.out);
@@ -60,8 +65,17 @@ files.forEach(function(connectorConfigFile) {
         }
     }
 
-    const imagePrefix = argv.local ? "localhost:5000/data61/" : "data61/";
-    const image = imagePrefix + configFile.type + ":" + getImageVersion();
+    function getImagePrefix() {
+        if (argv.imagePrefix) {
+            return argv.imagePrefix;
+        } else if (argv.local) {
+            return "localhost:5000/data61/";
+        } else {
+            return "data61/";
+        }
+    }
+
+    const image = getImagePrefix() + configFile.type + ":" + getImageVersion();
     const prod = argv.prod;
 
     const basename = path.basename(connectorConfigFile.path, ".json");


### PR DESCRIPTION
### What this PR does
Before we weren't updating the connectors (which live outside helm at the moment) when we deployed master via Gitlab. This meant that the connectors kept using the old version of images and the old version of the config. This updates the deploy to master step to update the config/images for the connector cron jobs.

### Checklist
- [x] Unit tests aren't applicable (delete one)
- [x] I've updated CHANGES.md with what I changed.
- [x] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column