### PR TITLE
Make web server look for client in the right place

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,7 @@
 *   Made frontend GA post to both terria and dga google analytics.
 *   Tagged correspondence api as a typescript api.
 *   Fixed up docker scripts to make them handle multiple versions of yarn packages coexisting.
+*   Made magda-web-server look for magda-web-client using require.resolve.
 
 ## 0.0.38
 

--- a/magda-web-server/src/index.ts
+++ b/magda-web-server/src/index.ts
@@ -126,15 +126,16 @@ app.use(
 
 app.use(morgan("combined"));
 
-const magda = path.join(__dirname, "..", "node_modules", "@magda");
-
-const clientRoot = path.join(magda, "web-client");
+const clientRoot = path.resolve(
+    require.resolve("@magda/web-client/package.json"),
+    ".."
+);
 const clientBuild = path.join(clientRoot, "build");
 console.log("Client: " + clientBuild);
 
-const adminRoot = path.join(magda, "web-admin");
-const adminBuild = path.join(adminRoot, "build");
-console.log("Admin: " + adminBuild);
+// const adminRoot = require.resolve("@magda/web-admin");
+// const adminBuild = path.join(adminRoot, "build");
+// console.log("Admin: " + adminBuild);
 
 const apiBaseUrl = addTrailingSlash(
     argv.apiBaseUrl || new URI(argv.baseUrl).segment("api").toString()
@@ -200,7 +201,7 @@ app.get("/server-config.js", function(req, res) {
     res.send("window.magda_server_config = " + JSON.stringify(config) + ";");
 });
 
-app.use("/admin", express.static(adminBuild));
+// app.use("/admin", express.static(adminBuild));
 app.use(express.static(clientBuild));
 
 // URLs in this list will load index.html and be handled by React routing.
@@ -228,12 +229,12 @@ app.get("/page/*", function(req, res) {
     res.sendFile(path.join(clientBuild, "index.html"));
 });
 
-app.get("/admin", function(req, res) {
-    res.sendFile(path.join(adminBuild, "index.html"));
-});
-app.get("/admin/*", function(req, res) {
-    res.sendFile(path.join(adminBuild, "index.html"));
-});
+// app.get("/admin", function(req, res) {
+//     res.sendFile(path.join(adminBuild, "index.html"));
+// });
+// app.get("/admin/*", function(req, res) {
+//     res.sendFile(path.join(adminBuild, "index.html"));
+// });
 
 if (argv.devProxy) {
     app.get("/api/*", function(req, res) {


### PR DESCRIPTION
### What this PR does

The web server previously always looked for the web client in its own `node_modules` directory and didn't fail if it couldn't find it.

This replaces that with a `require.resolve` based method that finds it in its new yarnified location and should fail if it can't.


### Checklist
- [x] Unit tests aren't applicable (delete one)
- [x] I've updated CHANGES.md with what I changed.
- [x] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column