### PR TITLE
remove double line on seerch box

### DIFF
--- a/magda-web-client/src/Components/Search/SearchBox.scss
+++ b/magda-web-client/src/Components/Search/SearchBox.scss
@@ -76,7 +76,9 @@
     input:focus {
         @include text();
         margin-bottom: 2px;
-        border-bottom: 2px solid #cfcfcf;
+        @media (min-width: $medium) {
+            border-bottom: 2px solid #cfcfcf;
+        }
     }
 
     .search-btn {

--- a/magda-web-client/src/Components/Search/SearchBox.scss
+++ b/magda-web-client/src/Components/Search/SearchBox.scss
@@ -17,14 +17,13 @@
     @media (min-width: $medium) {
         padding-bottom: 5px;
         margin-bottom: 0;
-        border-bottom: 2px solid hsla(0, 0%, 100%, 0.2);
+
         display: block;
         padding-top: 15px;
         font-family: $font-base;
         font-size: 33px;
         font-weight: 300;
         height: 57px;
-        border-bottom: 1px solid rgba(73, 73, 73, 0.15);
         padding-right: 50px;
         padding-bottom: 5px;
         margin-bottom: 0px;
@@ -77,13 +76,14 @@
     input:focus {
         @include text();
         margin-bottom: 2px;
+        border-bottom: 2px solid #cfcfcf;
     }
 
     .search-btn {
         position: absolute;
         right: 0;
         padding: 5px;
-        bottom: 0;
+        bottom: 1px;
         border: 2px solid transparent;
         box-sizing: border-box;
         display: inline-block;


### PR DESCRIPTION
### What this PR does
<img width="808" alt="screen shot 2018-05-15 at 1 35 05 pm" src="https://user-images.githubusercontent.com/7508939/40035410-f83d9422-5844-11e8-9494-c7f97d0db2c9.png">
consistent bottom border

### Checklist
- [x] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column