### PR TITLE
Stopped open data rating always showing 0 stars

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -47,6 +47,7 @@
 *   Made magda-web-server look for magda-web-client using require.resolve.
 *   Header adjustment for new design system.
 *   Updated notification with govau design systems components & fixed a few minor error handling related issues
+*   Fixed up datasets always showing as 0 stars.
 
 ## 0.0.38
 

--- a/magda-web-client/src/Components/Dataset/DatasetDetails.js
+++ b/magda-web-client/src/Components/Dataset/DatasetDetails.js
@@ -3,7 +3,7 @@ import TemporalAspectViewer from "../../UI/TemporalAspectViewer";
 import DatasetPreview from "./DatasetPreview";
 import DescriptionBox from "../../UI/DescriptionBox";
 import MarkdownViewer from "../../UI/MarkdownViewer";
-import StarRating from "../../UI/StarRating";
+import QualityIndicator from "../../UI/QualityIndicator";
 import TagsBox from "../../UI/TagsBox";
 import { connect } from "react-redux";
 import DistributionRow from "../DistributionRow";
@@ -42,8 +42,7 @@ class DatasetDetails extends Component {
                     </Medium>
                 </div>
                 <div className="quality-rating-box">
-                    <span>Open Data Quality</span>:
-                    <StarRating stars={dataset.linkedDataRating} />
+                    <QualityIndicator quality={dataset.linkedDataRating} />
                 </div>
                 <TagsBox tags={dataset.tags} />
                 <div className="dataset-preview">

--- a/magda-web-client/src/Components/Dataset/DatasetDetails.scss
+++ b/magda-web-client/src/Components/Dataset/DatasetDetails.scss
@@ -51,14 +51,9 @@
 .quality-rating-box {
     margin-top: 20px;
     margin-bottom: 20px;
-    position: relative;
+
     span {
         color: #535353;
-    }
-    .star-rating-box {
-        position: absolute;
-        margin-left: 10px;
-        top: 2px;
     }
 }
 

--- a/magda-web-client/src/Components/Dataset/DatasetSummary.js
+++ b/magda-web-client/src/Components/Dataset/DatasetSummary.js
@@ -2,7 +2,7 @@ import React, { Component } from "react";
 import MarkdownViewer from "../../UI/MarkdownViewer";
 import defined from "../../helpers/defined";
 import getDateString from "../../helpers/getDateString";
-import StarRating from "../../UI/StarRating";
+import QualityIndicator from "../../UI/QualityIndicator";
 import "./DatasetSummary.css";
 import { Link } from "react-router-dom";
 import uniq from "lodash.uniq";
@@ -67,10 +67,10 @@ export default class DatasetSummary extends Component {
                         </span>
                     )}
                     {defined(dataset.quality) && (
-                        <span className="dataset-summary-quality">
+                        <div className="dataset-summary-quality">
                             {" "}
-                            <StarRating stars={dataset.quality} />
-                        </span>
+                            <QualityIndicator quality={dataset.quality} />
+                        </div>
                     )}
                     {defined(
                         dataset.distributions &&

--- a/magda-web-client/src/Components/Dataset/DatasetSummary.scss
+++ b/magda-web-client/src/Components/Dataset/DatasetSummary.scss
@@ -49,12 +49,6 @@
         margin-right: 24px;
     }
 
-    .dataset-summary-downloads,
-    .dataset-summary-updated,
-    .dataset-summary-quality {
-        float: left;
-    }
-
     .dataset-summary-downloads {
         span {
             color: $AU-color-foreground-action;
@@ -70,5 +64,12 @@
                 content: "";
             }
         }
+    }
+
+    .dataset-summary-downloads,
+    .dataset-summary-updated,
+    .dataset-summary-quality {
+        float: left;
+        line-height: 1.5em;
     }
 }

--- a/magda-web-client/src/UI/QualityIndicator.js
+++ b/magda-web-client/src/UI/QualityIndicator.js
@@ -7,7 +7,7 @@ import helpIcon from "../assets/help-24.svg";
 import ReactTooltip from "react-tooltip";
 
 function QualityIndicator(props) {
-    let rating = Math.ceil(parseFloat(props.quality).toFixed(2) * 10 / 2) - 1;
+    let rating = Math.ceil(parseFloat(props.quality).toFixed(2) * 10 / 2);
 
     if (rating < 0) {
         rating = 0;

--- a/magda-web-client/src/UI/QualityIndicator.js
+++ b/magda-web-client/src/UI/QualityIndicator.js
@@ -1,0 +1,36 @@
+import React from "react";
+import { Link } from "react-router-dom";
+
+import StarRating from "./StarRating";
+import "./QualityIndicator.css";
+import helpIcon from "../assets/help-24.svg";
+import ReactTooltip from "react-tooltip";
+
+function QualityIndicator(props) {
+    let rating = Math.ceil(parseFloat(props.quality).toFixed(2) * 10 / 2) - 1;
+
+    if (rating < 0) {
+        rating = 0;
+    }
+
+    const tooltip = "Calculated using the Open Data scale";
+
+    return (
+        <div className="quality-indicator">
+            <span className="title">Open Data Quality:&nbsp;</span>
+            <StarRating stars={rating} />
+            <Link to="/page/dataset-quality" className="tooltip">
+                <img
+                    src={helpIcon}
+                    alt="Help Link"
+                    data-tip={tooltip}
+                    data-place="top"
+                    data-html={false}
+                />
+                <ReactTooltip />
+            </Link>
+        </div>
+    );
+}
+
+export default QualityIndicator;

--- a/magda-web-client/src/UI/QualityIndicator.scss
+++ b/magda-web-client/src/UI/QualityIndicator.scss
@@ -1,0 +1,22 @@
+.quality-indicator {
+    padding-right: 21px;
+
+    .title {
+        display: inline;
+        margin-right: 2px;
+    }
+
+    .tooltip {
+        margin-top: 2px;
+        color: #fff;
+        margin-left: 5px;
+        position: absolute;
+
+        &,
+        &:focus,
+        &:hover {
+            text-decoration: none;
+            border: none;
+        }
+    }
+}

--- a/magda-web-client/src/UI/StarRating.js
+++ b/magda-web-client/src/UI/StarRating.js
@@ -2,18 +2,14 @@ import React from "react";
 import PropTypes from "prop-types";
 import emptyStarIcon from "../assets/emptyStar.svg";
 import "./StarRating.css";
-import helpIcon from "../assets/help-24.svg";
-import ReactTooltip from "react-tooltip";
 import starIcon from "../assets/star.svg";
 
 function StarRating(props) {
     const stars = Array(5)
         .fill(emptyStarIcon)
         .fill(starIcon, 0, props.stars);
-    const tooltip =
-        "Calculated using the <a href='/page/dataset-quality'>Open Data scale</a>";
     return (
-        <span className="star-rating-box">
+        <div className="star-rating-box">
             {stars.map((icon, i) => (
                 <span
                     key={i}
@@ -24,17 +20,7 @@ function StarRating(props) {
                     <img key={i} src={icon} alt="star rating" />
                 </span>
             ))}
-            <span className="tooltip">
-                <img
-                    src={helpIcon}
-                    alt="Help Link"
-                    data-tip={tooltip}
-                    data-place="top"
-                    data-html={true}
-                />
-                <ReactTooltip />
-            </span>
-        </span>
+        </div>
     );
 }
 

--- a/magda-web-client/src/UI/StarRating.scss
+++ b/magda-web-client/src/UI/StarRating.scss
@@ -1,11 +1,7 @@
 .star-rating-box {
-    .tooltip a {
-        color: #fff;
-    }
+    display: inline;
+    vertical-align: middle;
 
-    .tooltip img {
-        margin-left: 5px;
-    }
     .full-star-icon {
         img {
             margin-bottom: 1px;

--- a/magda-web-client/src/actions/recordActions.js
+++ b/magda-web-client/src/actions/recordActions.js
@@ -55,7 +55,7 @@ export function fetchDatasetFromRegistry(id: string): Function {
             config.registryApiUrl +
             `records/${encodeURIComponent(
                 id
-            )}?aspect=dcat-dataset-strings&optionalAspect=dcat-distribution-strings&optionalAspect=dataset-distributions&optionalAspect=temporal-coverage&dereference=true&optionalAspect=dataset-publisher&optionalAspect=source&optionalAspect=link-status&optionalAspect=dataset-quality-rating`;
+            )}?dereference=true&aspect=dcat-dataset-strings&optionalAspect=dcat-distribution-strings&optionalAspect=dataset-distributions&optionalAspect=temporal-coverage&optionalAspect=dataset-publisher&optionalAspect=source&optionalAspect=link-status&optionalAspect=dataset-quality-rating`;
         return fetch(url)
             .then(response => {
                 if (response.status === 200) {


### PR DESCRIPTION
### What this PR does
Right now the star ratings only show 0 stars because at some point the `QualityIndicator` component, which translated from fractions of 1 to numbers of stars, was removed at some point. This reinstates it and does some other housekeeping around the star ratings - particularly making the link for the tooltip on the questionmark (the link in the tooltip text isn't clickable), and fixing the alignment.



### Checklist
- [x] Unit tests aren't applicable (delete one)
- [x] I've updated CHANGES.md with what I changed.
- [x] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column