### PR TITLE
Modified DescriptionBox font-size

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -48,6 +48,7 @@
 *   Added tooltip to future dates on datepicker
 *   Header adjustment for new design system.
 *   Updated notification with govau design systems components & fixed a few minor error handling related issues
+*   Modified `Show full description` font-size.
 
 ## 0.0.38
 

--- a/magda-web-client/src/UI/DescriptionBox.scss
+++ b/magda-web-client/src/UI/DescriptionBox.scss
@@ -1,5 +1,8 @@
 @import "../variables";
 .description-box {
+    span {
+        font-size: 1rem;
+    }
     .toggle-button {
         color: $AU-color-foreground-action;
         border: none;


### PR DESCRIPTION
### What this PR does
Modifies `Show full description` toggle box `font-size` to now be 1erm

**Before:**
![before](https://user-images.githubusercontent.com/1501560/40210838-a8561eaa-5a8a-11e8-8e8a-39e381af4988.PNG)


**After:**
![after](https://user-images.githubusercontent.com/1501560/40210846-b4002a98-5a8a-11e8-876c-a0dd30f72951.PNG)


### Checklist
- [x] Unit tests aren't applicable
- [x] I've updated CHANGES.md with what I changed.
- [x] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column