### PR TITLE
Added spacing between publisher and created date

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -48,6 +48,7 @@
 *   Added tooltip to future dates on datepicker
 *   Header adjustment for new design system.
 *   Updated notification with govau design systems components & fixed a few minor error handling related issues
+*   Added spacing between dataset publisher and created date.
 
 ## 0.0.38
 

--- a/magda-web-client/src/Components/RecordHandler.js
+++ b/magda-web-client/src/Components/RecordHandler.js
@@ -141,7 +141,7 @@ class RecordHandler extends React.Component {
                                     {publisherName}
                                 </span>
                             </span>
-                            <span className="separator hidden-sm">/</span>
+                            <span className="separator hidden-sm"> / </span>
                             {defined(this.props.dataset.issuedDate) && (
                                 <span className="updated-date hidden-sm">
                                     Created{" "}


### PR DESCRIPTION
### What this PR does
Add spacing between data set details publisher and created date.

**BEFORE:**
![before](https://user-images.githubusercontent.com/900555/40151500-c14197cc-59c3-11e8-945e-e312c5165560.png)

---
**AFTER:**
![preview](https://user-images.githubusercontent.com/1501560/40211212-ae4e0348-5a8c-11e8-92bf-bff01b887e0e.PNG)


### Checklist
- [x] Unit tests aren't applicable
- [x] I've updated CHANGES.md with what I changed.
- [x] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column