### PR TITLE
Issue/1009 Added bottom margin to all static pages

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -49,6 +49,7 @@
 *   Header adjustment for new design system.
 *   Updated notification with govau design systems components & fixed a few minor error handling related issues
 *   Fixed up datasets always showing as 0 stars.
+*   Added bottom margin to all static pages.
 
 ## 0.0.38
 

--- a/magda-web-client/src/Components/StaticPage.js
+++ b/magda-web-client/src/Components/StaticPage.js
@@ -17,7 +17,7 @@ export default function StaticPage(props) {
                     config.appName
                 }
             >
-                <div className={`container page-${id}`}>
+                <div className={`static-page-container container page-${id}`}>
                     <h1> {content.title && content.title} </h1>
                     <div
                         className="markdown-body"

--- a/magda-web-client/src/Components/StaticPage.scss
+++ b/magda-web-client/src/Components/StaticPage.scss
@@ -10,3 +10,6 @@
         margin-bottom: 0.5333333333em;
     }
 }
+.static-page-container {
+    margin-bottom: 150px;
+}


### PR DESCRIPTION
### What this PR does

Now all static pages have no gap between content and footer.

This PR added 150px bottom margin to all static pages.

### Checklist
- [ ] Unit tests aren't applicable
- [ ] I've updated CHANGES.md with what I changed.
- [ ] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column