### PR TITLE
Added link for organisation to link to their page

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -53,6 +53,7 @@
 *   Added spacing between dataset publisher and created date.
 *   Fixed up datasets always showing as 0 stars.
 *   Added bottom margin to all static pages.
+*   Reimplemented links from publisher names to their respective page.
 
 ## 0.0.38
 

--- a/magda-web-client/src/Components/RecordHandler.js
+++ b/magda-web-client/src/Components/RecordHandler.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { connect } from "react-redux";
+import { Link } from "react-router-dom";
 import ProgressBar from "../UI/ProgressBar";
 import ReactDocumentTitle from "react-document-title";
 import { bindActionCreators } from "redux";
@@ -54,7 +55,9 @@ class RecordHandler extends React.Component {
         const publisherName = this.props.dataset.publisher.name;
         const searchText =
             queryString.parse(this.props.location.search).q || "";
-        // const publisherId = this.props.dataset.publisher ? this.props.dataset.publisher.id : null;
+        const publisherId = this.props.dataset.publisher
+            ? this.props.dataset.publisher.id
+            : null;
 
         if (this.props.match.params.distributionId) {
             if (this.props.distributionIsFetching) {
@@ -137,9 +140,9 @@ class RecordHandler extends React.Component {
                                 itemScope
                                 itemType="http://schema.org/Organization"
                             >
-                                <span className="publisher" itemProp="name">
+                                <Link to={`/publishers/${publisherId}`}>
                                     {publisherName}
-                                </span>
+                                </Link>
                             </span>
                             <span className="separator hidden-sm"> / </span>
                             {defined(this.props.dataset.issuedDate) && (


### PR DESCRIPTION
### What this PR does
Adds link for publisher to link to their page from `DatasetSummary.js`


### Checklist
- [x] Unit tests aren't applicable
- [x] I've updated CHANGES.md with what I changed.
- [x] I've linked this PR to an issue in ZenHub