### PR TITLE
Added standard space after download button on DatasetDetails

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -53,6 +53,7 @@
 *   Added spacing between dataset publisher and created date.
 *   Fixed up datasets always showing as 0 stars.
 *   Added bottom margin to all static pages.
+*   Added standard space in between Download / New tab buttons on `DatasetDetails`.
 
 ## 0.0.38
 

--- a/magda-web-client/src/Components/DistributionRow.js
+++ b/magda-web-client/src/Components/DistributionRow.js
@@ -230,7 +230,7 @@ class DistributionRow extends Component {
                                 Download
                             </a>
                         </button>
-                    ) : null}
+                    ) : null}{" "}
                     <button
                         className="au-btn au-btn--secondary new-tab-button"
                         onClick={() => {


### PR DESCRIPTION
### What this PR does
Add a space in between Download and New Tab button.


### Checklist
- [x] Unit tests aren't applicable
- [x] I've updated CHANGES.md with what I changed.
- [x] I've linked this PR to an issue in ZenHub