### PR TITLE
Issue/994 Recent search caches images to avoid flickering icons issue on the first display

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -53,6 +53,7 @@
 *   Added spacing between dataset publisher and created date.
 *   Fixed up datasets always showing as 0 stars.
 *   Added bottom margin to all static pages.
+*   Recent search caches images to avoid flickering icons issue on the first display
 
 ## 0.0.38
 

--- a/magda-web-client/src/Components/Search/SearchSuggestionBox.js
+++ b/magda-web-client/src/Components/Search/SearchSuggestionBox.js
@@ -39,10 +39,23 @@ class SearchSuggestionBox extends Component {
             recentSearches: this.retrieveLocalData("recentSearches"),
             selectedItemIdx: null
         };
+        this.cacheImgs();
         this.createSearchDataFromProps(this.props);
         this.searchInputRef = null;
         this.onSearchInputKeyDown = this.onSearchInputKeyDown.bind(this);
         this.containerRef = null;
+        this.cacheImages = [];
+    }
+
+    cacheImg(img) {
+        const imgLoader = new Image();
+        imgLoader.src = img;
+        this.cacheImages.push(imgLoader);
+    }
+
+    cacheImgs() {
+        this.cacheImg(recentSearchImg);
+        this.cacheImg(closeImg);
     }
 
     retrieveLocalData(key): searchDataType {

--- a/magda-web-client/src/Components/Search/SearchSuggestionBox.js
+++ b/magda-web-client/src/Components/Search/SearchSuggestionBox.js
@@ -44,7 +44,6 @@ class SearchSuggestionBox extends Component {
         this.searchInputRef = null;
         this.onSearchInputKeyDown = this.onSearchInputKeyDown.bind(this);
         this.containerRef = null;
-        this.cacheImages = [];
     }
 
     cacheImg(img) {
@@ -54,6 +53,7 @@ class SearchSuggestionBox extends Component {
     }
 
     cacheImgs() {
+        this.cacheImages = [];
         this.cacheImg(recentSearchIcon);
         this.cacheImg(closeIcon);
     }

--- a/magda-web-client/src/Components/Search/SearchSuggestionBox.js
+++ b/magda-web-client/src/Components/Search/SearchSuggestionBox.js
@@ -46,16 +46,16 @@ class SearchSuggestionBox extends Component {
         this.containerRef = null;
     }
 
-    cacheImg(img) {
-        const imgLoader = new Image();
-        imgLoader.src = img;
-        this.cacheImages.push(imgLoader);
-    }
-
     cacheImgs() {
+        const cacheImg = img => {
+            const imgLoader = new Image();
+            imgLoader.src = img;
+            this.cacheImages.push(imgLoader);
+        };
+
         this.cacheImages = [];
-        this.cacheImg(recentSearchIcon);
-        this.cacheImg(closeIcon);
+        cacheImg(recentSearchIcon);
+        cacheImg(closeIcon);
     }
 
     retrieveLocalData(key): searchDataType {

--- a/magda-web-client/src/Components/Search/SearchSuggestionBox.js
+++ b/magda-web-client/src/Components/Search/SearchSuggestionBox.js
@@ -54,8 +54,8 @@ class SearchSuggestionBox extends Component {
     }
 
     cacheImgs() {
-        this.cacheImg(recentSearchImg);
-        this.cacheImg(closeImg);
+        this.cacheImg(recentSearchIcon);
+        this.cacheImg(closeIcon);
     }
 
     retrieveLocalData(key): searchDataType {


### PR DESCRIPTION
### What this PR does

Recent search now caches images to avoid flickering icons issue on the first display

Tested on Gitlab demo site.

### Checklist
- [x] Unit tests aren't applicable
- [x] I've updated CHANGES.md with what I changed.
- [x] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column