### PR TITLE
restyle search suggestion box

### DIFF
--- a/magda-web-client/src/Components/Search/SearchSuggestionBox.js
+++ b/magda-web-client/src/Components/Search/SearchSuggestionBox.js
@@ -348,7 +348,9 @@ class SearchSuggestionBox extends Component {
                     onMouseOut={() => this.onMouseOut()}
                 >
                     <Medium>
-                        <h5>Recent Searches</h5>
+                        <h5 className="search-suggestion__heading">
+                            Recent Searches
+                        </h5>
                     </Medium>
                     {recentSearchItems.map((item, idx) => (
                         <div
@@ -359,15 +361,15 @@ class SearchSuggestionBox extends Component {
                                     : ""
                             }`}
                         >
+                            <img
+                                className="recent-item-icon"
+                                src={recentSearchIcon}
+                                alt="recent search item"
+                            />
                             <button
                                 className="au-btn au-btn--tertiary search-item-main-button"
                                 onClick={e => this.onSearchItemClick(e, item)}
                             >
-                                <img
-                                    className="recent-item-icon"
-                                    src={recentSearchIcon}
-                                    alt="recent search item"
-                                />
                                 <Medium>
                                     <MarkdownViewer
                                         markdown={this.createSearchItemLabelText(

--- a/magda-web-client/src/Components/Search/SearchSuggestionBox.scss
+++ b/magda-web-client/src/Components/Search/SearchSuggestionBox.scss
@@ -12,6 +12,11 @@
     position: absolute;
     z-index: 2;
     color: $body;
+    .search-suggestion__heading {
+        font-weight: 500;
+        font-size: 10px;
+        text-transform: uppercase;
+    }
     .search-suggestion-box-position-adjust {
         @media (max-width: $medium - 1) {
             height: 3px;
@@ -35,45 +40,18 @@
             border-bottom-right-radius: 4px;
         }
         button.search-item-main-button {
-            display: block;
-            width: 100%;
+            width: calc(100% - 50px);
             text-align: left;
-            margin: 0px;
-            padding-left: 0px;
-            font-size: small;
-            height: auto;
-            @media (max-width: $medium - 1) {
-                padding-left: 10px;
-                box-shadow: inset 0px -1px 0px rgba(73, 73, 73, 0.15);
-                padding-top: 8px;
-                padding-bottom: 8px;
-            }
-            .recent-item-icon {
-                @media (min-width: $medium) {
-                    margin-top: 3px;
-                    margin-left: 3px;
+            padding: 8px;
+            &.markdown {
+                margin-left: 0;
+                em {
+                    font-weight: 500;
                 }
-                @media (max-width: $medium - 1) {
-                    margin-top: 5.5px;
-                }
-                float: left;
-                width: 25px;
-                opacity: 0.2;
             }
         }
         button.search-item-delete-button {
-            position: absolute;
-            right: 1px;
-            top: -4px;
-            width: 25px;
-            height: 25px;
-            padding: 0px;
-            border: none;
-            cursor: pointer;
-            @media (max-width: $medium - 1) {
-                margin-top: 16px;
-                margin-right: 5px;
-            }
+            padding: 0;
             img {
                 width: 13px;
                 height: 13px;
@@ -82,29 +60,13 @@
         }
         .search-item-container {
             position: relative;
+            display: flex;
             @media (max-width: $medium - 1) {
                 box-shadow: inset 0px -1px 0px rgba(73, 73, 73, 0.15);
             }
         }
     }
-    h5 {
-        font-size: 10px;
-        font-weight: 500px;
-        text-transform: uppercase;
-    }
-    .markdown {
-        margin-left: 32px;
-        padding: 2px;
-        white-space: initial;
-        line-height: 20px;
-        em {
-            font-weight: 500;
-        }
-    }
-    .recent-item-content {
-        margin-left: 39px;
-        line-height: 2.2rem;
-    }
+
     .selected {
         color: rgba(0, 0, 0, 0.87);
         background: #f2f2f2 !important;

--- a/magda-web-client/src/Components/Search/SearchSuggestionBox.scss
+++ b/magda-web-client/src/Components/Search/SearchSuggestionBox.scss
@@ -42,7 +42,7 @@
         button.search-item-main-button {
             width: calc(100% - 50px);
             text-align: left;
-            padding: 8px;
+            padding: 0px;
             &.markdown {
                 margin-left: 0;
                 em {
@@ -51,7 +51,7 @@
             }
         }
         button.search-item-delete-button {
-            padding: 0;
+            padding: 8px;
             img {
                 width: 13px;
                 height: 13px;
@@ -64,6 +64,10 @@
             @media (max-width: $medium - 1) {
                 box-shadow: inset 0px -1px 0px rgba(73, 73, 73, 0.15);
             }
+        }
+
+        .recent-item-icon {
+            padding: 8px;
         }
     }
 


### PR DESCRIPTION
### What this PR does
restyled search suggestion box
Desktop:
<img width="676" alt="screen shot 2018-05-22 at 4 27 23 pm" src="https://user-images.githubusercontent.com/7508939/40345569-0f011f92-5ddd-11e8-971a-6a510bce78b1.png">

Mobile:
<img width="656" alt="screen shot 2018-05-22 at 4 27 29 pm" src="https://user-images.githubusercontent.com/7508939/40345568-0ec4ad00-5ddd-11e8-9124-5fb2f1e595a4.png">

### Checklist
- [x] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column