### PR TITLE
Refactored react-tooltip to vanilla tooltip

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -64,6 +64,7 @@
 *   Modified `DatasetSummary` description style to be default `au-body`
 *   Tweaked `au-btn` border-right to be white for search facets.
 *   Made all data.gov.au environments use mailgun.
+*   Implemented `Tooltip` component to replace `react-tooltip` from `QualityIndicator`
 
 ## 0.0.38
 

--- a/magda-web-client/src/UI/QualityIndicator.js
+++ b/magda-web-client/src/UI/QualityIndicator.js
@@ -1,10 +1,8 @@
-import React from "react";
-import { Link } from "react-router-dom";
-
-import StarRating from "./StarRating";
 import "./QualityIndicator.css";
-import helpIcon from "../assets/help-24.svg";
-import ReactTooltip from "react-tooltip";
+
+import React from "react";
+import StarRating from "./StarRating";
+import Tooltip from "./Tooltip";
 
 function QualityIndicator(props) {
     let rating = Math.ceil(parseFloat(props.quality).toFixed(2) * 10 / 2);
@@ -13,22 +11,11 @@ function QualityIndicator(props) {
         rating = 0;
     }
 
-    const tooltip = "Calculated using the Open Data scale";
-
     return (
         <div className="quality-indicator">
             <span className="title">Open Data Quality:&nbsp;</span>
             <StarRating stars={rating} />
-            <Link to="/page/dataset-quality" className="tooltip">
-                <img
-                    src={helpIcon}
-                    alt="Help Link"
-                    data-tip={tooltip}
-                    data-place="top"
-                    data-html={false}
-                />
-                <ReactTooltip />
-            </Link>
+            <Tooltip />
         </div>
     );
 }

--- a/magda-web-client/src/UI/QualityIndicator.scss
+++ b/magda-web-client/src/UI/QualityIndicator.scss
@@ -5,18 +5,4 @@
         display: inline;
         margin-right: 2px;
     }
-
-    .tooltip {
-        margin-top: 2px;
-        color: #fff;
-        margin-left: 5px;
-        position: absolute;
-
-        &,
-        &:focus,
-        &:hover {
-            text-decoration: none;
-            border: none;
-        }
-    }
 }

--- a/magda-web-client/src/UI/Tooltip.js
+++ b/magda-web-client/src/UI/Tooltip.js
@@ -1,0 +1,24 @@
+import "./Tooltip.css";
+
+import React from "react";
+import { Link } from "react-router-dom";
+
+import helpIcon from "../assets/help-24.svg";
+
+/**
+ * @description Return a information tooltip, on hover show calculation method.
+ * @returns { div }
+ */
+const Tooltip = () => {
+    return (
+        <div className="tooltip">
+            <img src={helpIcon} alt="Help Link" />
+            <span className="tooltiptext">
+                Calculated using the{" "}
+                <Link to="/page/dataset-quality">Open data scale</Link>
+            </span>
+        </div>
+    );
+};
+
+export default Tooltip;

--- a/magda-web-client/src/UI/Tooltip.scss
+++ b/magda-web-client/src/UI/Tooltip.scss
@@ -1,0 +1,51 @@
+.tooltip {
+    position: absolute;
+    display: inline;
+    margin-left: 5px;
+    margin-top: 1px;
+}
+
+.tooltip .tooltiptext {
+    visibility: hidden;
+    width: 258px;
+    background-color: #222;
+    color: #fff;
+    text-align: center;
+    padding: 8px 21px;
+    position: absolute;
+    z-index: 1;
+    bottom: 150%;
+    left: -513%;
+    margin-left: -60px;
+    border-radius: 2px;
+    box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
+
+    a {
+        color: #fff;
+    }
+}
+
+.tooltip img {
+    margin: 0;
+    display: inline-block;
+}
+
+.tooltip .tooltiptext::after {
+    content: "";
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    margin-left: -5px;
+    border-width: 5px;
+    border-style: solid;
+    border-color: #222 transparent transparent transparent;
+}
+
+.tooltip:hover .tooltiptext {
+    visibility: visible;
+}
+
+.tooltiptext {
+    transition-delay: 1s;
+    transition: all 1s ease;
+}


### PR DESCRIPTION
### What this PR does
Refactored react-tooltip to vanilla tooltip, if this is _safter_ than `react-tooltip` I can tidy it up to make it more user friendly and replace all instances of `react-tooltip`...Yet another package with hundreds of dependencies :(

The emulation mobile testing in Chrome seemed to be ok, haven't done real mobile testing though...might spin up a gitlab preview?

### Checklist
- [x] Unit tests aren't applicable
- [x] I've updated CHANGES.md with what I changed.
- [x] I've linked this PR to an issue in ZenHub