### PR TITLE
Issue/834 Map preview: Set default camera & mute errors to user

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -64,6 +64,9 @@
 *   Modified `DatasetSummary` description style to be default `au-body`
 *   Tweaked `au-btn` border-right to be white for search facets.
 *   Made all data.gov.au environments use mailgun.
+*   Map Preview: Set default camera to Australia & set map to 2d
+*   Map Preview: Mute errors from users
+*   Map Preview: Report selected distribution to console
 
 ## 0.0.38
 

--- a/magda-preview-map/index.js
+++ b/magda-preview-map/index.js
@@ -31,6 +31,7 @@ import GazetteerSearchProviderViewModel from "terriajs/lib/ViewModels/GazetteerS
 import GnafSearchProviderViewModel from "terriajs/lib/ViewModels/GnafSearchProviderViewModel.js";
 import defined from "terriajs-cesium/Source/Core/defined";
 import render from "./lib/Views/render";
+import knockout from "terriajs-cesium/Source/ThirdParty/knockout";
 
 import createCatalogMemberFromType from "terriajs/lib/Models/createCatalogMemberFromType";
 import MagdaCatalogItem from "./lib/Models/MagdaCatalogItem";
@@ -63,6 +64,18 @@ const viewState = new ViewState({
     terria: terria
 });
 
+knockout.getObservable(viewState, "notifications").subscribe(function() {
+    if (!viewState.notifications || !viewState.notifications.length) return;
+    const notification = viewState.notifications.shift();
+    if (!notification) return;
+    let msg = "";
+    if (typeof notification === "string") msg = notification;
+    else if (notification.message) msg = notification.message;
+    else msg = String(notification);
+    if (!console || !console.log) return;
+    console.log(`Preview Map notifcation: \n ${msg}`);
+});
+
 if (process.env.NODE_ENV === "development") {
     window.viewState = viewState;
 }
@@ -72,6 +85,12 @@ if (process.env.NODE_ENV === "development") {
 if (process.env.NODE_ENV !== "production" && module.hot) {
     document.styleSheets[0].disabled = true;
 }
+
+window.raiseErrorToUser = e => {
+    raiseErrorToUser(terria, e);
+};
+
+window.viewState = viewState;
 
 terria
     .start({
@@ -84,8 +103,7 @@ terria
         })
     })
     .otherwise(function(e) {
-        if (console && console.log) console.log(e);
-        //raiseErrorToUser(terria, e);
+        raiseErrorToUser(terria, e);
     })
     .always(function() {
         try {

--- a/magda-preview-map/index.js
+++ b/magda-preview-map/index.js
@@ -86,12 +86,6 @@ if (process.env.NODE_ENV !== "production" && module.hot) {
     document.styleSheets[0].disabled = true;
 }
 
-window.raiseErrorToUser = e => {
-    raiseErrorToUser(terria, e);
-};
-
-window.viewState = viewState;
-
 terria
     .start({
         // If you don't want the user to be able to control catalog loading via the URL, remove the applicationUrl property below

--- a/magda-preview-map/index.js
+++ b/magda-preview-map/index.js
@@ -84,7 +84,8 @@ terria
         })
     })
     .otherwise(function(e) {
-        raiseErrorToUser(terria, e);
+        if (console && console.log) console.log(e);
+        //raiseErrorToUser(terria, e);
     })
     .always(function() {
         try {

--- a/magda-preview-map/package.json
+++ b/magda-preview-map/package.json
@@ -82,8 +82,8 @@
     },
     "scripts": {
         "start":
-            "bash ./node_modules/terriajs-server/run_server.sh --config-file devserverconfig.json",
-        "stop": "bash ./node_modules/terriajs-server/stop_server.sh",
+            "bash ../node_modules/terriajs-server/run_server.sh --config-file devserverconfig.json",
+        "stop": "bash ../node_modules/terriajs-server/stop_server.sh",
         "gulp": "gulp",
         "postinstall":
             "echo 'Installation with NPM successful. What to do next:\\n  npm start       # Starts the server on port 3001\\n  gulp watch      # Builds NationalMap and dependencies, and rebuilds if files change.'",
@@ -103,7 +103,7 @@
             "create-docker-context-for-node-component --build --push --tag auto",
         "compile": "gulp release",
         "build": "yarn run gulp release",
-        "dev": "npm start && gulp watch"
+        "dev": "yarn start && gulp watch"
     },
     "magda": {
         "language": "javascript",

--- a/magda-preview-map/wwwroot/init/terria.json
+++ b/magda-preview-map/wwwroot/init/terria.json
@@ -5,5 +5,6 @@
         "south": -45,
         "west": 109
     },
+    "viewerMode": "2d",
     "catalog": []
 }

--- a/magda-preview-map/wwwroot/init/terria.json
+++ b/magda-preview-map/wwwroot/init/terria.json
@@ -5,6 +5,5 @@
         "south": -45,
         "west": 109
     },
-    "viewerMode": "2d",
     "catalog": []
 }

--- a/magda-web-client/src/UI/DataPreviewMap.js
+++ b/magda-web-client/src/UI/DataPreviewMap.js
@@ -102,11 +102,11 @@ class DataPreviewMap extends Component {
                         }
                     ],
                     baseMapName: "Positron (Light)",
-                    initialCamera: {
-                        west: 123.48632812500001,
-                        south: -36.40359962073253,
-                        east: 143.52539062500003,
-                        north: -19.041348796589013
+                    homeCamera: {
+                        north: -8,
+                        east: 158,
+                        south: -45,
+                        west: 109
                     }
                 }
             ]

--- a/magda-web-client/src/UI/DataPreviewMap.js
+++ b/magda-web-client/src/UI/DataPreviewMap.js
@@ -57,6 +57,10 @@ class DataPreviewMap extends Component {
             });
             return;
         } else {
+            if (console && console.log) {
+                console.log("map preview distribution selection: ");
+                console.log(selectedDistribution);
+            }
             this.setState({
                 isInitLoading: false,
                 isMapLoading: true,

--- a/magda-web-client/src/UI/DataPreviewMap.js
+++ b/magda-web-client/src/UI/DataPreviewMap.js
@@ -97,7 +97,13 @@ class DataPreviewMap extends Component {
                             zoomOnEnable: true
                         }
                     ],
-                    baseMapName: "Positron (Light)"
+                    baseMapName: "Positron (Light)",
+                    initialCamera: {
+                        west: 123.48632812500001,
+                        south: -36.40359962073253,
+                        east: 143.52539062500003,
+                        north: -19.041348796589013
+                    }
                 }
             ]
         };
@@ -210,7 +216,7 @@ class DataPreviewMap extends Component {
                             frameBorder="0"
                             src={
                                 config.previewMapUrl +
-                                "#mode=preview&hideExplorerPanel=1&clean"
+                                "#mode=preview&hideExplorerPanel=1"
                             }
                             ref={f => (this.iframeRef = f)}
                             style={


### PR DESCRIPTION
### What this PR does

- Set default camera
- Also, set the map to 2d to reduce the animation duration
- Mute errors from user but report to console
- Report select distribution to console so that it's easier to investigate in future
- Make yarn dev running

To test mute errors from users, you can add the followings after [here](https://github.com/TerriaJS/magda/blob/master/magda-preview-map/index.js#L75):

```
window.raiseErrorToUser = e => {
    raiseErrorToUser(terria, e);
};
```
Then, you can trigger an error by (if embeded as iframe):
```
window.iframes[0].raiseErrorToUser(new Error("sssss"))
```
or (if access map module directly)
```
window.raiseErrorToUser(new Error("sssss"))
```

### Checklist
- [x] Unit tests aren't applicable
- [x] I've updated CHANGES.md with what I changed.
- [x] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column