### PR TITLE
Issue/1044 fixed pagination button styles

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -65,6 +65,7 @@
 *   Tweaked `au-btn` border-right to be white for search facets.
 *   Remove feedback form & button from both desktop & mobile view
 *   Made all data.gov.au environments use mailgun.
+*   Adjusted pagination button styles
 
 ## 0.0.38
 

--- a/magda-web-client/src/UI/Pagination.js
+++ b/magda-web-client/src/UI/Pagination.js
@@ -19,7 +19,7 @@ class Pagination extends Component {
         return (
             <button
                 onClick={this.onClick.bind(this, currentIndex - 1)}
-                className="btn-prev au-btn"
+                className="btn-prev au-btn au-btn--secondary"
             >
                 {" "}
                 <img src={left_arrow} alt="previous page" />{" "}
@@ -41,7 +41,7 @@ class Pagination extends Component {
 
     renderDisabledButton() {
         return (
-            <button className="au-btn" disabled={true}>
+            <button className="au-btn au-btn--secondary" disabled={true}>
                 ...
             </button>
         );
@@ -59,8 +59,8 @@ class Pagination extends Component {
                             <li key={i}>
                                 <button
                                     onClick={this.onClick.bind(this, i)}
-                                    className={`${
-                                        i === current ? "current" : ""
+                                    className={`au-btn ${
+                                        i === current ? "" : "au-btn--secondary"
                                     }`}
                                 >
                                     {i}
@@ -71,8 +71,8 @@ class Pagination extends Component {
                         <li>
                             <button
                                 onClick={this.onClick.bind(this, max)}
-                                className={`${
-                                    max === current ? "current" : ""
+                                className={`au-btn ${
+                                    max === current ? "" : "au-btn--secondary"
                                 }`}
                             >
                                 {max}
@@ -87,7 +87,10 @@ class Pagination extends Component {
                     {current > 1 && this.renderPrevButton(current)}
                     {margins.map(i => (
                         <li key={i}>
-                            <button onClick={this.onClick.bind(this, i)}>
+                            <button
+                                className="au-btn au-btn--secondary"
+                                onClick={this.onClick.bind(this, i)}
+                            >
                                 {i}
                             </button>
                         </li>
@@ -95,15 +98,18 @@ class Pagination extends Component {
                     <li>{this.renderDisabledButton()}</li>
                     <li>
                         <button
+                            className="au-btn"
                             onClick={this.onClick.bind(this, current)}
-                            className="current"
                         >
                             {current}
                         </button>
                     </li>
                     <li>{this.renderDisabledButton()}</li>
                     <li>
-                        <button onClick={this.onClick.bind(this, max)}>
+                        <button
+                            className="au-btn au-btn--secondary"
+                            onClick={this.onClick.bind(this, max)}
+                        >
                             {max}
                         </button>
                     </li>
@@ -118,7 +124,9 @@ class Pagination extends Component {
                         <li key={i}>
                             <button
                                 onClick={this.onClick.bind(this, i)}
-                                className={`${i === current ? "current" : ""}`}
+                                className={`au-btn ${
+                                    i === current ? "" : "au-btn--secondary"
+                                }`}
                             >
                                 {i}
                             </button>


### PR DESCRIPTION
### What this PR does

To fix it ( #1044 ), the following rules are applied:
- All buttons are now au-btn
- Non-current/active button use `secondary` style

Tested the situation:
- current page >3 or <=3 page
- total page no. > or < 5

### Checklist
- [x] Unit tests aren't applicable
- [x] I've updated CHANGES.md with what I changed.
- [x] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column