### PR TITLE
Issue/1035 Location filter: Make state selectable on the inital region filter panel open

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 *   Changed Publishers to Organisations in UI
 *   Modified `MonthPicker` tooltip icon's right padding
+*   Location filter: Make state selectable on the inital region filter panel open
 
 ## 0.0.39
 

--- a/magda-web-client/src/Components/SearchFacets/FacetRegion.js
+++ b/magda-web-client/src/Components/SearchFacets/FacetRegion.js
@@ -49,6 +49,7 @@ class FacetRegion extends Component {
     onFeatureClick(feature) {
         let regionMapping = this.props.regionMapping;
         let regionType = this.state._activeRegion.regionType;
+        if (!regionType) regionType = "STE";
 
         let regionProp = regionMapping[regionType].regionProp;
         let nameProp = regionMapping[regionType].nameProp;

--- a/magda-web-client/src/Components/SearchFacets/RegionMap.js
+++ b/magda-web-client/src/Components/SearchFacets/RegionMap.js
@@ -68,10 +68,7 @@ class RegionMap extends Component {
     }
 
     shouldRegionUpdate(preProps, nextProps) {
-        if (
-            !defined(nextProps.regionMapping) ||
-            !defined(nextProps.region.regionType)
-        ) {
+        if (!defined(nextProps.regionMapping)) {
             return false;
         } else if (
             this.layer &&
@@ -116,7 +113,9 @@ class RegionMap extends Component {
 
     addRegion(props) {
         this.removeRegion();
-        let regionData = props.regionMapping[props.region.regionType];
+        let regionType = props.region.regionType;
+        if (!regionType) regionType = "STE";
+        let regionData = props.regionMapping[regionType];
         if (defined(regionData)) {
             this.getID = function(feature) {
                 return feature.properties[regionData.regionProp];


### PR DESCRIPTION
### What this PR does

Add state layer on initial region filter panel open.
Make states & territory selectable.

### Checklist
- [x] Unit tests aren't applicable
- [x] I've updated CHANGES.md with what I changed.
- [x] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column