### PR TITLE
Removed underline from coat of arms on mobile

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 *   Changed Publishers to Organisations in UI
 *   Modified `MonthPicker` tooltip icon's right padding
 *   Location filter: Make state selectable on the inital region filter panel open
+*   Removed underline on coat of arms.
 
 ## 0.0.39
 

--- a/magda-web-client/src/Components/Header/Header.scss
+++ b/magda-web-client/src/Components/Header/Header.scss
@@ -52,6 +52,11 @@
         display: flex;
         justify-content: space-between;
         align-items: center;
+
+        .mobile-logo-link {
+            border: none;
+        }
+
         .mobile-logo {
             margin: 10px;
         }

--- a/magda-web-client/src/Components/Header/HeaderMobile.js
+++ b/magda-web-client/src/Components/Header/HeaderMobile.js
@@ -23,7 +23,7 @@ class HeaderMobile extends Component {
         return (
             <div className="mobile-header">
                 <div className="mobile-header-inner">
-                    <Link to="/">
+                    <Link to="/" className="mobile-logo-link">
                         <img
                             className="mobile-logo"
                             src={govtLogo}


### PR DESCRIPTION
### What this PR does
Removes the border from the coat of arms link on mobile.



### Checklist
- [x] Unit tests aren't applicable (delete one)
- [x] I've updated CHANGES.md with what I changed.
- [x] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column