### PR TITLE
Bumped regions version

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -82,6 +82,7 @@
 *   Map Preview: Mute errors from users
 *   Map Preview: Report selected distribution to console
 *   Adjusted pagination button styles
+*   Bumped regions index version to 31 because of region shortname
 
 ## 0.0.38
 

--- a/magda-scala-common/src/main/resources/common.conf
+++ b/magda-scala-common/src/main/resources/common.conf
@@ -3,7 +3,7 @@ elasticSearch {
 
   indices {
     regions {
-      version = 20
+      version = 21
     }
 
     datasets {

--- a/magda-scala-common/src/main/scala/au/csiro/data61/magda/search/elasticsearch/IndexDefinition.scala
+++ b/magda-scala-common/src/main/scala/au/csiro/data61/magda/search/elasticsearch/IndexDefinition.scala
@@ -120,7 +120,7 @@ object IndexDefinition extends DefaultJsonProtocol {
   val regions: IndexDefinition =
     new IndexDefinition(
       name = "regions",
-      version = 20,
+      version = 21,
       indicesIndex = Indices.RegionsIndex,
       definition = (indices, config) =>
         create.index(indices.getIndex(config, Indices.RegionsIndex))


### PR DESCRIPTION
### What this PR does
Bumps the regions version so that it creates itself a new index with crispy's abbreviations in it.

You can test it at http://1120-bump-regions-version.magda-dev.terria.io/search - there's no datasets because that's broken but the regions are already loaded if you use the locations facet.

### Checklist
- [x] Unit tests aren't applicable (delete one)
- [x] I've updated CHANGES.md with what I changed.
- [x] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column