### PR TITLE
Added redirect for CKAN dataset URLs (UUID or slug)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,7 @@
 -   Fixed a issue that state region layer could be removed from region filter panel map
 -   Adjust search box placeholder color to be more visible on mobile and more consistent on desktop
 -   Corrected email template style to be inline with designs.
+-   Added redirect for CKAN dataset URLs (UUID or slug) to their new canonical location
 
 ## 0.0.40
 

--- a/magda-web-client/src/Components/Search/Search.js
+++ b/magda-web-client/src/Components/Search/Search.js
@@ -1,5 +1,6 @@
 import "./Search.css";
 import { connect } from "react-redux";
+import { Redirect } from "react-router-dom";
 import { config } from "../../config";
 import defined from "../../helpers/defined";
 import Pagination from "../../UI/Pagination";
@@ -164,6 +165,19 @@ class Search extends Component {
                                             />
                                         )}
 
+                                        {// redirect if we came from a 404 error and there is only one result
+                                        queryString.parse(
+                                            this.props.location.search
+                                        ).notfound &&
+                                            this.props.datasets.length ===
+                                                1 && (
+                                                <Redirect
+                                                    to={`/dataset/${encodeURI(
+                                                        this.props.datasets[0]
+                                                            .identifier
+                                                    )}/details`}
+                                                />
+                                            )}
                                         <SearchResults
                                             strategy={this.props.strategy}
                                             searchResults={this.props.datasets}


### PR DESCRIPTION
### What this PR does
Added redirect for CKAN dataset URLs (UUID or slug) including resource URLs (just back to the main dataset page)

### Checklist
- [x] I've updated CHANGES.md with what I changed.
- [x] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column