### PR TITLE
Fixed display of chart axis config dropdowns in Firefox

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ## 0.0.41
 
+*   Fixed display of chart axis config dropdowns in Firefox.
 *   Fixed LanguageAnalyzerSpec from generating stop words as search values.
 *   Updated prettier config to not reformat package.json in to an invalid 4 space tab width.
 

--- a/magda-web-client/src/UI/ChartConfig.js
+++ b/magda-web-client/src/UI/ChartConfig.js
@@ -35,13 +35,17 @@ export default class ChartConfig extends Component {
                         ? options.map(
                               (o, idx) =>
                                   typeof o === "string" ? (
-                                      <option key={o} value={o} label={o} />
+                                      <option key={o} value={o} label={o}>
+                                          {o}
+                                      </option>
                                   ) : (
                                       <option
                                           key={idx}
                                           value={idx}
                                           label={o.label}
-                                      />
+                                      >
+                                          {o.label}
+                                      </option>
                                   )
                           )
                         : null}


### PR DESCRIPTION
### What this PR does
Fixed display of chart axis config dropdowns in Firefox by including the label between the opening and closing option tags <option>


### Checklist
- [x] Unit tests aren't applicable
- [x] I've updated CHANGES.md with what I changed
- [x] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column