### PR TITLE
Issue/1007 make sure buttons & format icons is at the middle position of each section

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 *   Fixed display of chart axis config dropdowns in Firefox.
 *   Fixed LanguageAnalyzerSpec from generating stop words as search values.
 *   Updated prettier config to not reformat package.json in to an invalid 4 space tab width.
+*   Positioned the buttons & format icons at middle position of the Files & APIs section
 
 ## 0.0.40
 

--- a/magda-web-client/src/Components/DistributionRow.scss
+++ b/magda-web-client/src/Components/DistributionRow.scss
@@ -8,6 +8,7 @@
     .format-icon {
         width: 32px;
         height: 32px;
+        margin-top: 14px;
     }
     .distribution-row-link {
         color: $AU-color-foreground-text;
@@ -50,6 +51,7 @@
     }
     .button-area {
         text-align: left;
+        margin-top: 11px;
         @media (min-width: $medium) {
             text-align: right;
         }


### PR DESCRIPTION
### What this PR does

On dataset page / `Files & APIs` section:
make sure buttons & format icons is at the middle position of each section


### Checklist
- [x] Unit tests aren't applicable
- [x] I've updated CHANGES.md with what I changed.
- [x] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column