### PR TITLE
Issue1108 mobile logo

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ## 0.0.41
 
+*   Make mobiel logo bigger, fixed a bug in safari
 *   Create Suggest a Dataset Page
 *   Add Suggest a Dataset on search results page
 *   Fixed display of chart axis config dropdowns in Firefox.

--- a/magda-web-client/src/Components/Header/HeaderMobile.js
+++ b/magda-web-client/src/Components/Header/HeaderMobile.js
@@ -27,7 +27,7 @@ class HeaderMobile extends Component {
                         <img
                             className="mobile-logo"
                             src={govtLogo}
-                            height={36}
+                            height={50}
                             alt="au Gov logo"
                         />
                     </Link>

--- a/magda-web-client/src/Components/Search/SearchBox.scss
+++ b/magda-web-client/src/Components/Search/SearchBox.scss
@@ -165,15 +165,19 @@
             color: $AU-color-foreground-action;
         }
         input::-webkit-input-placeholder {
+            padding: 0 10px;
             color: rgba($AU-color-foreground-action, 0.7);
         }
         input::-moz-placeholder {
+            padding: 0 10px;
             color: rgba($AU-color-foreground-action, 0.7);
         }
         input:-ms-input-placeholder {
+            padding: 0 10px;
             color: rgba($AU-color-foreground-action, 0.7);
         }
         input:-moz-placeholder {
+            padding: 0 10px;
             color: rgba($AU-color-foreground-action, 0.7);
         }
         input:focus::-webkit-input-placeholder {


### PR DESCRIPTION
### What this PR does

the logo is already in svg, yet it looks very low quality on mobile. Possibly because the logo is quite complicated, viewing it such small size cause browser not able to render all details. I made it 10px bigger, seems to be improved.

Also fixed a bug in safari (search box placeholder text misalignment on the homepage)

### Checklist
- [x] I've updated CHANGES.md with what I changed.
- [x] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column