### PR TITLE
Added 1.5em vertical space for chart field elements, minor corrections

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
 *   Updated prettier config to not reformat package.json in to an invalid 4 space tab width.
 *   Positioned the buttons & format icons at middle position of the Files & APIs section
 *   Made publisher acronym search case insensitive & added test cases
+*   Added vertical spacing for `DataPreview` chart fields.
 
 ## 0.0.40
 

--- a/magda-web-client/src/UI/ChartConfig.js
+++ b/magda-web-client/src/UI/ChartConfig.js
@@ -57,7 +57,7 @@ export default class ChartConfig extends Component {
     renderIconSelect() {
         return (
             <div className="chart-config_icon-select">
-                <label tabIndex="-1">Chart type</label>
+                <label tabIndex="-1">Chart Type</label>
                 {ChartDatasetEncoder.avlChartTypes.map(v => (
                     <button
                         className={this.props.chartType === v ? "isActive" : ""}
@@ -81,7 +81,7 @@ export default class ChartConfig extends Component {
             <div className="chart-config">
                 <div className="chart-type">{this.renderIconSelect()}</div>
                 <div className="chart-title">
-                    <label htmlFor="chart-title">chart title</label>
+                    <label htmlFor="chart-title">Chart Title</label>
                     <input
                         className="au-text-input"
                         name="text-input"
@@ -95,14 +95,14 @@ export default class ChartConfig extends Component {
                         value={this.props.chartTitle}
                     />
                 </div>
-                <div className="y-axis">
+                <div className="x-axis">
                     {this.renderDropdownSelect(
                         this.props.xAxisOptions,
                         "xAxis",
                         "xAxis"
                     )}
                 </div>
-                <div className="x-axis">
+                <div className="y-axis">
                     {this.renderDropdownSelect(
                         this.props.yAxisOptions,
                         "yAxis",

--- a/magda-web-client/src/UI/ChartConfig.scss
+++ b/magda-web-client/src/UI/ChartConfig.scss
@@ -14,15 +14,15 @@
         }
     }
     .chart-type {
-        margin-top: 1.5em;
+        margin-top: 1em;
     }
     .chart-title {
-        margin-top: 1.5em;
+        margin-top: 1em;
     }
     .x-axis {
-        margin-top: 1.5em;
+        margin-top: 1em;
     }
     .y-axis {
-        margin-top: 1.5em;
+        margin-top: 1em;
     }
 }

--- a/magda-web-client/src/UI/ChartConfig.scss
+++ b/magda-web-client/src/UI/ChartConfig.scss
@@ -1,15 +1,28 @@
-.chart-config{
-  .chart-config_icon-select{
-    button{
-      background: transparent;
-      border: 0;
-      box-shadow: 0;
-      margin-right: 2px;
-      border: 1px solid rgba(0,0,0,0);
-      padding: 4px;
-      &.isActive, &:hover{
-        border: 1px solid rgba(0,0,0,.26);
-      }
+.chart-config {
+    .chart-config_icon-select {
+        button {
+            background: transparent;
+            border: 0;
+            box-shadow: 0;
+            margin-right: 2px;
+            border: 1px solid rgba(0, 0, 0, 0);
+            padding: 4px;
+            &.isActive,
+            &:hover {
+                border: 1px solid rgba(0, 0, 0, 0.26);
+            }
+        }
     }
-  }
+    .chart-type {
+        margin-top: 1.5em;
+    }
+    .chart-title {
+        margin-top: 1.5em;
+    }
+    .x-axis {
+        margin-top: 1.5em;
+    }
+    .y-axis {
+        margin-top: 1.5em;
+    }
 }


### PR DESCRIPTION
### What this PR does
Adds `1.5em` vertical spacing to `DataPreview` chart fields.
Corrects `xAxis` and `yAxis` naming, capitalised field titles.


### Checklist
- [x] Unit tests aren't applicable (delete one)
- [x] I've updated CHANGES.md with what I changed.
- [x] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column