### PR TITLE
Made format and publisher autocomplete give correct doc counts.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,7 @@
 -   Positioned the buttons & format icons at middle position of the Files & APIs section
 -   Made publisher acronym search case insensitive & added test cases
 -   Added vertical spacing for `DataPreview` chart fields.
+-   Stopped format/publisher filter search returning wrong doc counts when there's no text query.
 
 ## 0.0.40
 

--- a/magda-web-client/src/Components/SearchFacets/Format.js
+++ b/magda-web-client/src/Components/SearchFacets/Format.js
@@ -43,7 +43,7 @@ class Format extends Component {
     onSearchFormatFacet() {
         this.props.dispatch(
             fetchFormatSearchResults(
-                queryString.parse(this.props.location.search).q
+                queryString.parse(this.props.location.search).q || "*"
             )
         );
     }

--- a/magda-web-client/src/Components/SearchFacets/Publisher.js
+++ b/magda-web-client/src/Components/SearchFacets/Publisher.js
@@ -45,7 +45,7 @@ class Publisher extends Component {
     onSearchPublisherFacet() {
         this.props.dispatch(
             fetchPublisherSearchResults(
-                queryString.parse(this.props.location.search).q
+                queryString.parse(this.props.location.search).q || "*"
             )
         );
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11307,7 +11307,7 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-prettier@^1.11.1:
+prettier@^1.13.4:
   version "1.13.4"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.13.4.tgz#31bbae6990f13b1093187c731766a14036fa72e6"
 


### PR DESCRIPTION
### What this PR does
Short term fix before https://github.com/TerriaJS/magda/issues/979 gets done.

Right now when they get doc counts, the publisher and format filter parse the current url directly, using the "q" param and passing that all the way to the search api. Unfortunately since then we've made it that the "q" param isn't always present, so this defaults it to "*" in line with the actual search.

### Checklist
- [x] Unit tests aren't applicable (delete one)
- [x] I've updated CHANGES.md with what I changed.
- [x] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column
- [x] There are sufficient comments for my code to be understandable - and I realise reviewers will pull me up on it if not!
