### PR TITLE
Cache the yarn cache in gitlab, not node_modules

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,7 +13,6 @@ stages:
   - release
   - deploy-prod
 
-
 builders-and-yarn:
   stage: builders
   image: registry.gitlab.com/magda-data/magda/data61/magda-builder-docker:master
@@ -24,11 +23,12 @@ builders-and-yarn:
     - .yarn
     - "yarn.lock"
   before_script:
+    - rm -rf node_modules
+    - yarn config set cache-folder .yarn
     - yarn install
   services:
     - docker:dind
   script:
-    - yarn config set cache-folder .yarn
     - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN $CI_REGISTRY
     - yarn run in-submodules -- -f categories.builder=true -- run docker-build-prod --include-filtered-dependencies -- -- --repository=$CI_REGISTRY/magda-data/magda --version=$CI_COMMIT_REF_SLUG --cacheFromVersion=master
   artifacts:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,12 +18,11 @@ builders-and-yarn:
   image: registry.gitlab.com/magda-data/magda/data61/magda-builder-docker:master
   retry: 1
   cache:
-    key: $CI_JOB_NAME
+    key: $CI_JOB_NAME-yarn-cache-test
     paths:
     - .yarn
     - "yarn.lock"
   before_script:
-    - rm -rf node_modules
     - yarn config set cache-folder .yarn
     - yarn install
   services:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,14 +21,14 @@ builders-and-yarn:
   cache:
     key: $CI_JOB_NAME
     paths:
-    - "node_modules"
-    - "*/node_modules"
+    - .yarn
     - "yarn.lock"
   before_script:
     - yarn install
   services:
     - docker:dind
   script:
+    - yarn config set cache-folder .yarn
     - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN $CI_REGISTRY
     - yarn run in-submodules -- -f categories.builder=true -- run docker-build-prod --include-filtered-dependencies -- -- --repository=$CI_REGISTRY/magda-data/magda --version=$CI_COMMIT_REF_SLUG --cacheFromVersion=master
   artifacts:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,7 @@ builders-and-yarn:
   image: registry.gitlab.com/magda-data/magda/data61/magda-builder-docker:master
   retry: 1
   cache:
-    key: $CI_JOB_NAME-yarn-cache-test
+    key: $CI_JOB_NAME-yarn-cache
     paths:
     - .yarn
     - "yarn.lock"
@@ -70,7 +70,6 @@ generate-connector-jobs:
     paths:
       - "deploy/kubernetes/generated"
     expire_in: 30 days
-
 
 buildtest:search-with-index-cache:
   stage: buildtest

--- a/yarn.lock
+++ b/yarn.lock
@@ -11307,7 +11307,7 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-prettier@^1.11.1:
+prettier@^1.13.4:
   version "1.13.4"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.13.4.tgz#31bbae6990f13b1093187c731766a14036fa72e6"
 


### PR DESCRIPTION
### What this PR does
Rather than cache `node_modules`, this uses the yarn cache. This means that best-case-scenario builds are a bit slower because everything in `node_modules` has to be rebuilt, but also means that the size of the cache being uploaded/downloaded each time is smaller, and importantly should help with the problems we've been seeing recently where the cached `node_modules` folder doesn't quite match `yarn.lock` or `package.json` and yarn ends up taking up to an hour and failing on step 

### Checklist
- [x] Unit tests aren't applicable (delete one)
- [x] I've updated CHANGES.md with what I changed.
- [x] There are sufficient comments for my code to be understandable - and I realise reviewers will pull me up on it if not!
