### PR TITLE
Filters now move to top once filter is applied

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 -   Added Zendesk feedback widget activated via footer link
 -   Made end of content spacing consistent
 -   Added `flex` display and set consistent padding from footer.
+-   Made filter selections move only when applied on publisher and format
 
 ## 0.0.41
 

--- a/magda-web-client/src/Components/SearchFacets/FacetBasicBody.js
+++ b/magda-web-client/src/Components/SearchFacets/FacetBasicBody.js
@@ -49,6 +49,7 @@ class FacetBasicBody extends Component {
     onToggleOption(option) {
         const existingOptions = this.state._activeOptions.map(o => o.value);
         const index = existingOptions.indexOf(option.value);
+        // if the option is already selected remove it from _activeOptions
         if (index > -1) {
             this.setState({
                 _activeOptions: [
@@ -56,6 +57,7 @@ class FacetBasicBody extends Component {
                     ...this.state._activeOptions.slice(index + 1)
                 ]
             });
+            //else add it to the activeOptions
         } else {
             this.setState({
                 _activeOptions: [...this.state._activeOptions, option]
@@ -107,12 +109,8 @@ class FacetBasicBody extends Component {
     }
 
     render() {
-        let that = this;
-        // default list of options to display for the facet filter except those already active, which will be displayed in a seperate list
-        let inactiveOptions = this.props.options.filter(
-            o => !this.checkActiveOption(o)
-        );
-        // the option that has the max object.value value, use to calculate volumne indicator
+        let options = this.props.options;
+        // the option that has the max hit value, use to calculate volumne indicator
         let maxOptionOptionList = maxBy(this.props.options, o => +o.hitCount);
         return (
             <div className={`facet-body facet-${this.props.title}`}>
@@ -128,24 +126,7 @@ class FacetBasicBody extends Component {
                 {this.state.showOptions && (
                     <div>
                         <div className="facet-body-buttons">
-                            <ul className="list--unstyled facet-option__list">
-                                {that.state._activeOptions
-                                    .sort((a, b) => b.hitCount - a.hitCount)
-                                    .map(o => (
-                                        <li key={`${o.value}-${o.hitCount}`}>
-                                            {that.renderOption(
-                                                o,
-                                                maxOptionOptionList
-                                            )}
-                                        </li>
-                                    ))}
-                                {this.props.options.length === 0 && (
-                                    <li className="no-data">
-                                        No {this.props.title} available
-                                    </li>
-                                )}
-                            </ul>
-                            {inactiveOptions.map(o =>
+                            {options.map(o =>
                                 this.renderOption(o, maxOptionOptionList)
                             )}
                         </div>
@@ -167,7 +148,6 @@ class FacetBasicBody extends Component {
                                 }
                                 onClick={this.onApplyFilter}
                             >
-                                {" "}
                                 Apply{" "}
                             </button>
                         </div>

--- a/magda-web-client/src/Components/SearchFacets/SearchFacets.scss
+++ b/magda-web-client/src/Components/SearchFacets/SearchFacets.scss
@@ -131,10 +131,12 @@
     padding: 0 8px;
     cursor: pointer;
     &.is-active,
-    &:hover,
-    &:focus {
+    &:hover {
         background-color: $AU-color-foreground-action;
         color: $AU-color-background;
+    }
+    &:focus {
+        outline: none;
     }
 }
 


### PR DESCRIPTION
### What this PR does
Filters now don't move until they have been applied.
### Checklist

-   [x] There are unit tests to verify my changes are correct | Unit tests aren't applicable (delete one)
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column
-   [x] There are sufficient comments for my code to be understandable - and I realise reviewers will pull me up on it if not!
