### PR TITLE
Issue/1188 Search Organisation API ( Created for Frontend Testing )

### DIFF
--- a/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/search/elasticsearch/ElasticSearchIndexer.scala
+++ b/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/search/elasticsearch/ElasticSearchIndexer.scala
@@ -446,7 +446,7 @@ class ElasticSearchIndexer(
         .source(Map(
           "identifier" -> publisher.identifier.toJson,
           "acronym" -> publisher.acronym.toJson,
-          "description" -> publiser.description.toJson,
+          "description" -> publisher.description.toJson,
           "value" -> publisherName.toJson).toJson)))
 
     val indexFormats = dataSet.distributions.filter(dist => dist.format.isDefined && !"".equals(dist.format.get)).map { distribution =>

--- a/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/search/elasticsearch/ElasticSearchIndexer.scala
+++ b/magda-indexer/src/main/scala/au/csiro/data61/magda/indexer/search/elasticsearch/ElasticSearchIndexer.scala
@@ -446,6 +446,7 @@ class ElasticSearchIndexer(
         .source(Map(
           "identifier" -> publisher.identifier.toJson,
           "acronym" -> publisher.acronym.toJson,
+          "description" -> publiser.description.toJson,
           "value" -> publisherName.toJson).toJson)))
 
     val indexFormats = dataSet.distributions.filter(dist => dist.format.isDefined && !"".equals(dist.format.get)).map { distribution =>

--- a/magda-registry-aspects/organization-details.schema.json
+++ b/magda-registry-aspects/organization-details.schema.json
@@ -19,10 +19,6 @@
             "title":
                 "The URL of an image representing the organization, such as its logo.",
             "type": "string"
-        },
-        "datasetCount": {
-            "title": "The number indexed datasets for this organization.",
-            "type": "integer"
         }
     }
 }

--- a/magda-registry-aspects/organization-details.schema.json
+++ b/magda-registry-aspects/organization-details.schema.json
@@ -19,6 +19,10 @@
             "title":
                 "The URL of an image representing the organization, such as its logo.",
             "type": "string"
+        },
+        "datasetCount": {
+            "title": "The number indexed datasets for this organization.",
+            "type": "integer"
         }
     }
 }

--- a/magda-scala-common/src/main/resources/common.conf
+++ b/magda-scala-common/src/main/resources/common.conf
@@ -7,7 +7,7 @@ elasticSearch {
     }
 
     datasets {
-      version = 32
+      version = 34
     }
   }
 }

--- a/magda-scala-common/src/main/scala/au/csiro/data61/magda/model/Misc.scala
+++ b/magda-scala-common/src/main/scala/au/csiro/data61/magda/model/Misc.scala
@@ -87,7 +87,8 @@ package misc {
     acronym: Option[String] = None,
     homePage: Option[String] = None,
     email: Option[String] = None,
-    imageUrl: Option[String] = None)
+    imageUrl: Option[String] = None,
+    dataSetCount: Option[Int] = None)
 
   case class Location(
     text: Option[String] = None,
@@ -377,7 +378,7 @@ package misc {
 
     implicit val distributionFormat = jsonFormat12(Distribution.apply)
     implicit val locationFormat = jsonFormat2(Location.apply)
-    implicit val agentFormat = jsonFormat7(Agent.apply)
+    implicit val agentFormat = jsonFormat8(Agent.apply)
     implicit val dataSetFormat = jsonFormat19(DataSet.apply)
     implicit val facetOptionFormat = jsonFormat6(FacetOption.apply)
     implicit val facetFormat = jsonFormat2(Facet.apply)

--- a/magda-scala-common/src/main/scala/au/csiro/data61/magda/model/Misc.scala
+++ b/magda-scala-common/src/main/scala/au/csiro/data61/magda/model/Misc.scala
@@ -88,7 +88,7 @@ package misc {
     homePage: Option[String] = None,
     email: Option[String] = None,
     imageUrl: Option[String] = None,
-    dataSetCount: Option[Int] = None)
+    dataSetCount: Option[Long] = None)
 
   case class Location(
     text: Option[String] = None,

--- a/magda-scala-common/src/main/scala/au/csiro/data61/magda/model/Misc.scala
+++ b/magda-scala-common/src/main/scala/au/csiro/data61/magda/model/Misc.scala
@@ -83,6 +83,7 @@ package misc {
   case class Agent(
     identifier: Option[String] = None,
     name: Option[String] = None,
+    description: Option[String] = None,
     acronym: Option[String] = None,
     homePage: Option[String] = None,
     email: Option[String] = None,
@@ -376,7 +377,7 @@ package misc {
 
     implicit val distributionFormat = jsonFormat12(Distribution.apply)
     implicit val locationFormat = jsonFormat2(Location.apply)
-    implicit val agentFormat = jsonFormat6(Agent.apply)
+    implicit val agentFormat = jsonFormat7(Agent.apply)
     implicit val dataSetFormat = jsonFormat19(DataSet.apply)
     implicit val facetOptionFormat = jsonFormat6(FacetOption.apply)
     implicit val facetFormat = jsonFormat2(Facet.apply)

--- a/magda-scala-common/src/main/scala/au/csiro/data61/magda/model/Registry.scala
+++ b/magda-scala-common/src/main/scala/au/csiro/data61/magda/model/Registry.scala
@@ -182,6 +182,7 @@ object Registry {
       Agent(
         identifier = Some(publisher.id),
         name = organizationDetails.extract[String]('title.?),
+        description = organizationDetails.extract[String]('description.?),
         acronym = getAcronymFromPublisherName(organizationDetails.extract[String]('title.?)),
         imageUrl = organizationDetails.extract[String]('imageUrl.?))
     }

--- a/magda-scala-common/src/main/scala/au/csiro/data61/magda/search/elasticsearch/IndexDefinition.scala
+++ b/magda-scala-common/src/main/scala/au/csiro/data61/magda/search/elasticsearch/IndexDefinition.scala
@@ -102,7 +102,7 @@ object IndexDefinition extends DefaultJsonProtocol {
           mapping(indices.getType(indices.typeForFacet(Publisher))).fields(
             keywordField("identifier"),
             textField("acronym").analyzer("keyword").searchAnalyzer("uppercase"),
-            magdaTextField("description")
+            magdaTextField("description"),
             magdaTextField("value"),
             textField("english").analyzer("english")))
         .analysis(

--- a/magda-scala-common/src/main/scala/au/csiro/data61/magda/search/elasticsearch/IndexDefinition.scala
+++ b/magda-scala-common/src/main/scala/au/csiro/data61/magda/search/elasticsearch/IndexDefinition.scala
@@ -56,7 +56,7 @@ object IndexDefinition extends DefaultJsonProtocol {
 
   val dataSets: IndexDefinition = new IndexDefinition(
     name = "datasets",
-    version = 32,
+    version = 34,
     indicesIndex = Indices.DataSetsIndex,
     definition = (indices, config) => {
       val baseDefinition = createIndex(indices.getIndex(config, Indices.DataSetsIndex))
@@ -74,6 +74,7 @@ object IndexDefinition extends DefaultJsonProtocol {
             objectField("publisher").fields(
               keywordField("identifier"),
               textField("acronym").analyzer("keyword").searchAnalyzer("uppercase"),
+              magdaTextField("description"),
               magdaTextField("name",
                 keywordField("keyword"),
                 textField("keyword_lowercase").analyzer("quote"))),

--- a/magda-scala-common/src/main/scala/au/csiro/data61/magda/search/elasticsearch/IndexDefinition.scala
+++ b/magda-scala-common/src/main/scala/au/csiro/data61/magda/search/elasticsearch/IndexDefinition.scala
@@ -102,6 +102,7 @@ object IndexDefinition extends DefaultJsonProtocol {
           mapping(indices.getType(indices.typeForFacet(Publisher))).fields(
             keywordField("identifier"),
             textField("acronym").analyzer("keyword").searchAnalyzer("uppercase"),
+            magdaTextField("description")
             magdaTextField("value"),
             textField("english").analyzer("english")))
         .analysis(

--- a/magda-search-api/src/main/scala/au/csiro/data61/magda/api/SearchApi.scala
+++ b/magda-search-api/src/main/scala/au/csiro/data61/magda/api/SearchApi.scala
@@ -70,11 +70,9 @@ class SearchApi(val searchQueryer: SearchQueryer)(implicit val config: Config, i
               "start" ? 0,
               "limit" ? 10
               )) { (generalQuery, start, limit) ⇒
-              val x = "ss"
-
               onSuccess(searchQueryer.searchOrganisations(generalQuery, start, limit)) { result =>
-                //val status = if (result.errorMessage.isDefined) StatusCodes.InternalServerError else StatusCodes.OK
-                complete(StatusCodes.OK, result)
+                val status = if (result.errorMessage.isDefined) StatusCodes.InternalServerError else StatusCodes.OK
+                complete(status, result)
               }
             }
           } ~

--- a/magda-search-api/src/main/scala/au/csiro/data61/magda/api/SearchApi.scala
+++ b/magda-search-api/src/main/scala/au/csiro/data61/magda/api/SearchApi.scala
@@ -64,6 +64,20 @@ class SearchApi(val searchQueryer: SearchQueryer)(implicit val config: Config, i
                 }
               }
           } ~
+          pathPrefix("organisations") {
+            (get & parameters(
+              'query?,
+              "start" ? 0,
+              "limit" ? 10
+              )) { (generalQuery, start, limit) ⇒
+              val x = "ss"
+
+              onSuccess(searchQueryer.searchOrganisations(generalQuery, start, limit)) { result =>
+                //val status = if (result.errorMessage.isDefined) StatusCodes.InternalServerError else StatusCodes.OK
+                complete(StatusCodes.OK, result)
+              }
+            }
+          } ~
           path("region-types") { get { getFromResource("regionMapping.json") } } ~
           path("regions") {
             (get & parameters('query?, "start" ? 0, "limit" ? 10)) { (query, start, limit) ⇒

--- a/magda-search-api/src/main/scala/au/csiro/data61/magda/api/model/Model.scala
+++ b/magda-search-api/src/main/scala/au/csiro/data61/magda/api/model/Model.scala
@@ -1,6 +1,6 @@
 package au.csiro.data61.magda.api.model
 
-import au.csiro.data61.magda.model.misc.{ DataSet, Facet, Region }
+import au.csiro.data61.magda.model.misc.{ DataSet, Facet, Region, Agent }
 import au.csiro.data61.magda.model.Temporal
 import au.csiro.data61.magda.model.Temporal.PeriodOfTime
 import au.csiro.data61.magda.model.misc
@@ -25,6 +25,12 @@ case class RegionSearchResult(
   query: Option[String],
   hitCount: Long,
   regions: List[Region])
+
+case class OrganisationsSearchResult(
+  query: Option[String],
+  hitCount: Long,
+  organisations: List[Agent]
+)
 
 trait Protocols extends DefaultJsonProtocol with Temporal.Protocols with misc.Protocols {
   implicit object SearchStrategyFormat extends JsonFormat[SearchStrategy] {
@@ -53,6 +59,9 @@ trait Protocols extends DefaultJsonProtocol with Temporal.Protocols with misc.Pr
   implicit val regionSearchResultFormat = {
     implicit val regionFormat = apiRegionFormat
     jsonFormat3(RegionSearchResult.apply)
+  }
+  implicit val OrganisationsSearchResultFormat = {
+    jsonFormat3(OrganisationsSearchResult.apply)
   }
 }
 

--- a/magda-search-api/src/main/scala/au/csiro/data61/magda/api/model/Model.scala
+++ b/magda-search-api/src/main/scala/au/csiro/data61/magda/api/model/Model.scala
@@ -29,7 +29,8 @@ case class RegionSearchResult(
 case class OrganisationsSearchResult(
   query: Option[String],
   hitCount: Long,
-  organisations: List[Agent]
+  organisations: List[Agent],
+  errorMessage: Option[String] = None
 )
 
 trait Protocols extends DefaultJsonProtocol with Temporal.Protocols with misc.Protocols {
@@ -61,7 +62,7 @@ trait Protocols extends DefaultJsonProtocol with Temporal.Protocols with misc.Pr
     jsonFormat3(RegionSearchResult.apply)
   }
   implicit val OrganisationsSearchResultFormat = {
-    jsonFormat3(OrganisationsSearchResult.apply)
+    jsonFormat4(OrganisationsSearchResult.apply)
   }
 }
 

--- a/magda-search-api/src/main/scala/au/csiro/data61/magda/search/SearchQueryer.scala
+++ b/magda-search-api/src/main/scala/au/csiro/data61/magda/search/SearchQueryer.scala
@@ -10,7 +10,7 @@ trait SearchQueryer {
   def search(query: Query, start: Long, limit: Int, facetSize: Int): Future[SearchResult]
   def searchFacets(facetType: FacetType, facetQuery: Option[String], generalQuery: Query, start: Long, limit: Int): Future[FacetSearchResult]
   def searchRegions(query: Option[String], start: Long, limit: Int): Future[RegionSearchResult]
-  def searchOrganisations(query: Option[String], start: Long, limit: Int): Future[OrganisationsSearchResult]
+  def searchOrganisations(query: Option[String], start: Int, limit: Int): Future[OrganisationsSearchResult]
 }
 
 sealed trait SearchStrategy {

--- a/magda-search-api/src/main/scala/au/csiro/data61/magda/search/SearchQueryer.scala
+++ b/magda-search-api/src/main/scala/au/csiro/data61/magda/search/SearchQueryer.scala
@@ -1,7 +1,7 @@
 package au.csiro.data61.magda.search
 
 import au.csiro.data61.magda.api.Query
-import au.csiro.data61.magda.api.model.{ RegionSearchResult, SearchResult }
+import au.csiro.data61.magda.api.model.{ RegionSearchResult, SearchResult, OrganisationsSearchResult }
 import au.csiro.data61.magda.model.misc._
 
 import scala.concurrent.Future
@@ -10,6 +10,7 @@ trait SearchQueryer {
   def search(query: Query, start: Long, limit: Int, facetSize: Int): Future[SearchResult]
   def searchFacets(facetType: FacetType, facetQuery: Option[String], generalQuery: Query, start: Long, limit: Int): Future[FacetSearchResult]
   def searchRegions(query: Option[String], start: Long, limit: Int): Future[RegionSearchResult]
+  def searchOrganisations(query: Option[String], start: Long, limit: Int): Future[OrganisationsSearchResult]
 }
 
 sealed trait SearchStrategy {

--- a/magda-search-api/src/main/scala/au/csiro/data61/magda/search/elasticsearch/ElasticSearchQueryer.scala
+++ b/magda-search-api/src/main/scala/au/csiro/data61/magda/search/elasticsearch/ElasticSearchQueryer.scala
@@ -453,6 +453,13 @@ class ElasticSearchQueryer(indices: Indices = DefaultIndices)(
         }).toList
         val totalCount = result.aggregations.cardinalityResult("totalCount").getValue
         Future(OrganisationsSearchResult(queryString, totalCount, orgs))
+      }.recover{
+        case RootCause(illegalArgument: IllegalArgumentException) =>
+          logger.error(illegalArgument, "Exception when searching")
+          OrganisationsSearchResult(queryString, 0, List(), Some("Bad argument: " + illegalArgument.getMessage))
+        case e: Throwable =>
+          logger.error(e, "Exception when searching")
+          OrganisationsSearchResult(queryString, 0, List(), Some("Error: " + e.getMessage))
       }
     }
 

--- a/magda-search-api/src/main/scala/au/csiro/data61/magda/search/elasticsearch/ElasticSearchQueryer.scala
+++ b/magda-search-api/src/main/scala/au/csiro/data61/magda/search/elasticsearch/ElasticSearchQueryer.scala
@@ -450,7 +450,7 @@ class ElasticSearchQueryer(indices: Indices = DefaultIndices)(
       d.publisher.map(o=> o.copy(dataSetCount = innerHit.map(h=>{
         h.totalHits
       })))
-    }).filter(_.isDefined).map(_.getOrElse(new Agent)).toList
+    }).filter(_.isDefined).map(_.get).toList
 
     Future(OrganisationsSearchResult(queryString, 0, orgs))
   }


### PR DESCRIPTION
### What this PR does

**the only thing left for this PR now are test cases**

This PR is created for frontend development testing (otherwise could be too hard for frontend work).

Create a new API endpoint on search API:

http://localhost:6102/v0/organisations

If you access it outside the cluster, it should be:

http://cluster-host/api/v0/search/organisations

Support parameters (similar to dataset API):
- query: query string
- start: start record offset
- limit: how many records to retrieve

example:
http://cluster-host/api/v0/search/organisations?query=*&start=0&limit=10

Will return a response like:
```
{
    "query": "*",
    "hitCount": 160,
    "organisations": [
        {
            "acronym": "AGS",
            "name": "ABS Geospatial Solutions",
            "identifier": "org-dga-760c24b1-3c3d-4ccb-8196-41530fcdebd5",
            "description": "",
            "imageUrl": "http://www.abs.gov.au/ausstats/wmdata.nsf/activeotherresource/ABS_Logo_333/$File/ABS_Logo_333.svg",
            "dataSetCount": 34
        },
        {
            "acronym": "ACEFCRSJCU",
            "name": "ARC Centre of Excellence for Coral Reef Studies, James Cook University",
            "identifier": "org-dga-53a24fb3-52e7-4155-8c70-20e68cc1dde7",
            "description": "",
            "imageUrl": "",
            "dataSetCount": 8
        },
        {
            "acronym": "ASC",
            "name": "Alpine Shire Council",
            "identifier": "org-dga-23f904cc-9cd7-40d0-a494-c64a062bf0f7",
            "description": "Alpine Shire is a local government area in Victoria, Australia in the north-east of the state. It includes the towns of Bright, Mount Beauty and Myrtleford. It has an area of 4,885 square kilometres.",
            "imageUrl": "http://maps.alpineshire.vic.gov.au/logos/5124-Alpine-logo-(web_180px).png",
            "dataSetCount": 4
        },
        {
            "acronym": "AV",
            "name": "Arts Victoria",
            "identifier": "org-dga-742235a9-e1c5-42c2-9ba9-724692df3a46",
            "description": "Arts Victoria",
            "imageUrl": "https://data.gov.au/uploads/group/2016-08-19-151941.919526artsvictoria.jpg",
            "dataSetCount": 4
        },
        {
            "acronym": "AGD",
            "name": "Attorney General's Department",
            "identifier": "org-dga-8a004b69-6411-4ddf-82f7-873df1f65113",
            "description": "Attorney General's Department",
            "imageUrl": "https://data.gov.au/uploads/group/2016-08-19-152138.388868agd.gif",
            "dataSetCount": 3
        },
        {
            "acronym": "A",
            "name": "Ausgrid",
            "identifier": "org-dga-1d32be70-3734-4b95-a7bd-cfe09b89c24d",
            "description": "Ausgrid",
            "imageUrl": "https://data.gov.au/uploads/group/2016-08-19-152024.360231ausgrid.jpg",
            "dataSetCount": 2
        },
        {
            "acronym": "ACFA",
            "name": "Australia Council for the Arts",
            "identifier": "org-dga-ef0f77cc-4acd-42ee-9a6c-a674b8d71f7b",
            "description": "Australia Council for the Arts",
            "imageUrl": "https://data.gov.au/uploads/group/2016-08-19-152209.698142austco.gif",
            "dataSetCount": 1
        },
        {
            "acronym": "AAD",
            "name": "Australian Antarctic Division",
            "identifier": "org-dga-3e666ea1-f7c8-4382-a342-0e0bbc88ce9a",
            "description": "Australian Antarctic Division",
            "imageUrl": "http://data.aad.gov.au/static/images/aad_env_inline.png",
            "dataSetCount": 131
        },
        {
            "acronym": "ABC",
            "name": "Australian Broadcasting Corporation",
            "identifier": "org-dga-24f6ada6-f694-482f-b68f-a7cb10d7205a",
            "description": "Australian Broadcasting Corporation",
            "imageUrl": "https://data.gov.au/uploads/group/2016-08-19-152242.888953ABCmono.jpg",
            "dataSetCount": 20
        },
        {
            "acronym": "ABARES",
            "name": "Australian Bureau of Agriculture and Resource Economics and Sciences",
            "identifier": "org-dga-5a9f3a8e-2673-4c6e-be5b-e8f7287993c5",
            "description": "The Australian Bureau of Agriculture and Resource Economics and Sciences (ABARES) is the science and economics research division of the Department of Agriculture and Water Resources.",
            "imageUrl": "https://data.gov.au/uploads/group/2018-02-18-235753.917110ABARESstackedblack.png",
            "dataSetCount": 130
        }
    ]
}
```

~~Please note: the "hitCount" filed currently will be always 0
It supposed to be the total no. of the org records meet the search.
Will implement it later (need an extra query to `elasticsearch` as currently it returns total no. of datasets before aggregation)~~

The correct hitCount has been implmented via an cardinality aggregation.

The only thing left now are test cases

### Checklist

-   [ ] There are unit tests to verify my changes are correct | Unit tests aren't applicable (delete one)
-   [ ] I've updated CHANGES.md with what I changed.
-   [ ] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column
-   [ ] There are sufficient comments for my code to be understandable - and I realise reviewers will pull me up on it if not!
