### PR TITLE
Added bottom-border property to dataset filters

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@
 -   Removed underline from organisations in search
 -   Modified styling for `ask a question` button to use secondary AUButton styling.
 -   Restricted markdown <strong> tag to be default style.
+-   Added `bottom-border` property to make dataset filters stand out more.
 
 ## 0.0.41
 

--- a/magda-web-client/src/Components/SearchFacets/FacetBasicBody.js
+++ b/magda-web-client/src/Components/SearchFacets/FacetBasicBody.js
@@ -3,6 +3,7 @@ import find from "lodash.find";
 import maxBy from "lodash.maxby";
 import defined from "../../helpers/defined";
 import FacetSearchBox from "./FacetSearchBox";
+import "./FacetBasicBody.css";
 
 // extends Facet class
 class FacetBasicBody extends Component {
@@ -92,7 +93,7 @@ class FacetBasicBody extends Component {
                     className="btn-facet-option__volume-indicator"
                 />
                 <span className="btn-facet-option__name">
-                    {option.value} ({option.hitCount})
+                    {option.value} ( {option.hitCount} )
                 </span>
             </button>
         );

--- a/magda-web-client/src/Components/SearchFacets/FacetBasicBody.scss
+++ b/magda-web-client/src/Components/SearchFacets/FacetBasicBody.scss
@@ -1,0 +1,3 @@
+.facet-body-buttons .btn-facet-option {
+    border-bottom: 1px solid rgba(76, 42, 133, 0.1); //$AU-color-foreground-action
+}


### PR DESCRIPTION
### What this PR does
Adds `bottom-border` property to dataset filters.
Adds spacing between dataset count (###) -> ( ### )

## Preview:
![screen shot 2018-06-18 at 10 17 22 am](https://user-images.githubusercontent.com/1501560/41513497-d79d06ba-72e0-11e8-851a-5e82cdbc4b1d.png)


### Checklist

-   [x] There are unit tests to verify my changes are correct | Unit tests aren't applicable (delete one)
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column
-   [x] There are sufficient comments for my code to be understandable - and I realise reviewers will pull me up on it if not!
