### PR TITLE
Disable "redirect old CKAN URL slugs and UUIDs"

### DIFF
--- a/magda-web-client/src/Components/RecordHandler.js
+++ b/magda-web-client/src/Components/RecordHandler.js
@@ -156,21 +156,6 @@ class RecordHandler extends React.Component {
                     this.props.match.params.datasetId
                 )}`;
 
-                // redirect old CKAN URL slugs and UUIDs
-                if (
-                    this.props.dataset.identifier &&
-                    this.props.dataset.identifier !== "" &&
-                    this.props.dataset.identifier !==
-                        this.props.match.params.datasetId
-                ) {
-                    return (
-                        <Redirect
-                            to={`/dataset/${encodeURI(
-                                this.props.dataset.identifier
-                            )}/details?q=${searchText}`}
-                        />
-                    );
-                }
                 return (
                     <div itemScope itemType="http://schema.org/Dataset">
                         <div


### PR DESCRIPTION
### What this PR does
Disable "redirect old CKAN URL slugs and UUIDs". This was intend to promote use of new canonical urls but is not critical for the operation of the site/SEO.

### Checklist

-   [x] Unit tests aren't applicable (delete one)
-   [x] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (or there is no issue) and dragged it to the _Pull Request_ column
-   [x] There are sufficient comments for my code to be understandable - and I realise reviewers will pull me up on it if not!
