### PR TITLE
Fix org access bug.

### DIFF
--- a/magda-esri-portal-connector/aspect-templates/group-esri-access-control.js
+++ b/magda-esri-portal-connector/aspect-templates/group-esri-access-control.js
@@ -1,5 +1,5 @@
 return {
     groups: [group.id],
-    access: "shared",
+    access: group.access === "any authenticated users" ? "org" : "shared",
     expiration: transformer.expiration
 };


### PR DESCRIPTION
### What this PR does

Fixes #<insert issue number here if relevant>

Fix a bug where harvested items having "org" access attribute are not correctly assigned esri-access-control aspect, resulting in the items not being accessible by any users.

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [ ] I've updated CHANGES.md with what I changed.
-   [ ] I've linked this PR to an issue in ZenHub (core dev team only)
