### PR TITLE
Fix aspect schema non-compliance bugs.

### DIFF
--- a/magda-esri-portal-connector/aspect-templates/dcat-dataset-strings.js
+++ b/magda-esri-portal-connector/aspect-templates/dcat-dataset-strings.js
@@ -10,9 +10,14 @@ const dsExtent =
           }, ${dataset.extent[1][1]}`
         : undefined;
 
+const theKeywords =
+    dataset.tags === undefined || dataset.tags.length === 0
+        ? ["undefined"]
+        : dataset.tags;
+
 return {
     title: dataset.title || dataset.name,
-    description: dataset.description,
+    description: dataset.description || undefined,
     issued: moment.utc(dataset.created).format(),
     modified: moment.utc(dataset.created).format(),
     languages: dataset.culture ? [dataset.culture] : [],
@@ -23,7 +28,7 @@ return {
 
     // What does this equate to?
     themes: undefined,
-    keywords: dataset.tags,
+    keywords: theKeywords,
     contactPoint: dataset.owner,
     landingPage: esriPortal.getDatasetLandingPageUrl(dataset.id)
 };

--- a/magda-esri-portal-connector/aspect-templates/dcat-dataset-strings.js
+++ b/magda-esri-portal-connector/aspect-templates/dcat-dataset-strings.js
@@ -11,9 +11,7 @@ const dsExtent =
         : undefined;
 
 const theKeywords =
-    dataset.tags === undefined || dataset.tags.length === 0
-        ? ["undefined"]
-        : dataset.tags;
+    dataset.tags && dataset.tags.length === 0 ? undefined : dataset.tags;
 
 return {
     title: dataset.title || dataset.name,


### PR DESCRIPTION
### What this PR does

Fixes #[160](https://github.com/TerriaJS/nsw-digital-twin/issues/160), #[166 ](https://github.com/TerriaJS/nsw-digital-twin/issues/166)

Fixes to support magda-registry-api that is configured for `validateJsonSchema = true`.

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [ ] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
