### PR TITLE
Only admin users have access to record history of registry API.

### DIFF
--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/Api.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/Api.scala
@@ -66,7 +66,7 @@ class Api(val webHookActorOption: Option[ActorRef], val authClient: AuthApiClien
         pathPrefix("hooks") { new HooksService(config, webHookActor, authClient, system, materializer).route }
     case None =>
       pathPrefix("aspects") { new AspectsServiceRO(config, authClient, system, materializer).route } ~
-        pathPrefix("records") { new RecordsServiceRO(config, system, materializer).route }
+        pathPrefix("records") { new RecordsServiceRO(config, authClient, system, materializer).route }
   }
 
   val routes = handleExceptions(myExceptionHandler) {

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordHistoryService.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordHistoryService.scala
@@ -103,18 +103,26 @@ class RecordHistoryService(config: Config, authClient: AuthApiClient, system: Ac
   @ApiResponses(Array(
     new ApiResponse(code = 404, message = "No record exists with the given ID, it does not have a CreateRecord event, or it has been deleted.", response = classOf[BadRequest])
   ))
-  def version = get { path(Segment / "history" / Segment) { (id, version) => requiresTenantId { tenantId => { parameters('aspect.*, 'optionalAspect.*) { (aspects: Iterable[String], optionalAspects: Iterable[String]) =>
-    DB readOnly { session =>
-      val events = EventPersistence.streamEventsUpTo(version.toLong, recordId = Some(id), tenantId = tenantId)
-      val recordSource = recordPersistence.reconstructRecordFromEvents(id, events, aspects, optionalAspects)
-      val sink = Sink.head[Option[Record]]
-      val future = recordSource.runWith(sink)(materializer)
-      Await.result[Option[Record]](future, 5 seconds) match {
-        case Some(record) => complete(record)
-        case None => complete(StatusCodes.NotFound, BadRequest("No record exists with that ID, it does not have a CreateRecord event, or it has been deleted."))
+  def version = get {
+    path(Segment / "history" / Segment) { (id, version) =>
+      requireIsAdmin(authClient)(system, config) { _ =>
+        requiresTenantId { tenantId =>
+          parameters('aspect.*, 'optionalAspect.*) { (aspects: Iterable[String], optionalAspects: Iterable[String]) =>
+            DB readOnly { _ =>
+              val events = EventPersistence.streamEventsUpTo(version.toLong, recordId = Some(id), tenantId = tenantId)
+              val recordSource = recordPersistence.reconstructRecordFromEvents(id, events, aspects, optionalAspects)
+              val sink = Sink.head[Option[Record]]
+              val future = recordSource.runWith(sink)(materializer)
+              Await.result[Option[Record]](future, 5 seconds) match {
+                case Some(record) => complete(record)
+                case None => complete(StatusCodes.NotFound, BadRequest("No record exists with that ID, it does not have a CreateRecord event, or it has been deleted."))
+              }
+            }
+          }
+        }
       }
     }
-  } } } } }
+  }
 
   val route =
     history ~

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordsService.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordsService.scala
@@ -24,7 +24,7 @@ import scala.util.{Failure, Success}
 
 @Path("/records")
 @io.swagger.annotations.Api(value = "records", produces = "application/json")
-class RecordsService(config: Config, webHookActor: ActorRef, authClient: AuthApiClient, system: ActorSystem, materializer: Materializer, recordPersistence: RecordPersistence = DefaultRecordPersistence) extends RecordsServiceRO(config, system, materializer, recordPersistence) {
+class RecordsService(config: Config, webHookActor: ActorRef, authClient: AuthApiClient, system: ActorSystem, materializer: Materializer, recordPersistence: RecordPersistence = DefaultRecordPersistence) extends RecordsServiceRO(config, authClient, system, materializer, recordPersistence) {
   val logger = Logging(system, getClass)
   implicit val ec: ExecutionContext = system.dispatcher
 

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordsServiceRO.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/RecordsServiceRO.scala
@@ -7,6 +7,7 @@ import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
 import akka.stream.Materializer
+import au.csiro.data61.magda.client.AuthApiClient
 import au.csiro.data61.magda.directives.TenantDirectives.requiresTenantId
 import au.csiro.data61.magda.model.Registry._
 import au.csiro.data61.magda.registry.Directives.withRecordOpaQuery
@@ -21,6 +22,7 @@ import scala.concurrent.ExecutionContext
 @io.swagger.annotations.Api(value = "records", produces = "application/json")
 class RecordsServiceRO(
     config: Config,
+    authClient: AuthApiClient,
     system: ActorSystem,
     materializer: Materializer,
     recordPersistence: RecordPersistence = DefaultRecordPersistence
@@ -686,6 +688,6 @@ class RecordsServiceRO(
       getById ~
       getByIdSummary ~
       new RecordAspectsServiceRO(system, materializer, config).route ~
-      new RecordHistoryService(system, materializer).route
+      new RecordHistoryService(config, authClient, system, materializer).route
 
 }

--- a/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/RecordsServiceSpec.scala
+++ b/magda-registry-api/src/test/scala/au/csiro/data61/magda/registry/RecordsServiceSpec.scala
@@ -1893,12 +1893,12 @@ class RecordsServiceSpec extends ApiSpec {
           status shouldEqual StatusCodes.OK
         }
 
-        Get(s"/v0/records/${record.id}/history") ~> addTenantIdHeader(TENANT_1) ~> param.api(role).routes ~> check {
+        param.asAdmin(Get(s"/v0/records/${record.id}/history")) ~> addTenantIdHeader(TENANT_1) ~> param.api(role).routes ~> check {
           status shouldEqual StatusCodes.OK
           responseAs[EventsPage].events.length shouldEqual 1
         }
 
-        Get(s"/v0/records/${record.id}/history") ~> addTenantIdHeader(TENANT_2) ~> param.api(role).routes ~> check {
+        param.asAdmin(Get(s"/v0/records/${record.id}/history")) ~> addTenantIdHeader(TENANT_2) ~> param.api(role).routes ~> check {
           status shouldEqual StatusCodes.OK
           responseAs[EventsPage].events.length shouldEqual 0
         }
@@ -1919,7 +1919,7 @@ class RecordsServiceSpec extends ApiSpec {
           responseAs[Record].sourceTag shouldEqual Some("tag2")
         }
 
-        Get(s"/v0/records/${record.id}/history") ~> addTenantIdHeader(TENANT_1) ~> param.api(role).routes ~> check {
+        param.asAdmin(Get(s"/v0/records/${record.id}/history")) ~> addTenantIdHeader(TENANT_1) ~> param.api(role).routes ~> check {
           status shouldEqual StatusCodes.OK
           responseAs[EventsPage].events.length shouldEqual 1
         }
@@ -1929,7 +1929,7 @@ class RecordsServiceSpec extends ApiSpec {
           responseAs[Record] shouldEqual newRecord.copy(tenantId = Some(TENANT_2))
         }
 
-        Get(s"/v0/records/${record.id}/history") ~> addTenantIdHeader(TENANT_2) ~> param.api(role).routes ~> check {
+        param.asAdmin(Get(s"/v0/records/${record.id}/history")) ~> addTenantIdHeader(TENANT_2) ~> param.api(role).routes ~> check {
           status shouldEqual StatusCodes.OK
           responseAs[EventsPage].events.length shouldEqual 1
         }
@@ -2516,7 +2516,7 @@ class RecordsServiceSpec extends ApiSpec {
               status shouldEqual StatusCodes.NotFound
             }
 
-            Get(s"/v0/records/$recordId/history") ~> addTenantIdHeader(TENANT_1) ~> param.api(role).routes ~> check {
+            param.asAdmin(Get(s"/v0/records/$recordId/history")) ~> addTenantIdHeader(TENANT_1) ~> param.api(role).routes ~> check {
               status shouldEqual StatusCodes.OK
               val res = responseAs[EventsPage]
 


### PR DESCRIPTION
### What this PR does

Fixes [this issue](https://github.com/TerriaJS/nsw-digital-twin/issues/216)

Access to registry API `/records/<record id>/history` is limited to admin users only.

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [ ] I've updated CHANGES.md with what I changed.
-   [ ] I've linked this PR to an issue in ZenHub (core dev team only)
