### PR TITLE
Respect public access attribute of a portal group.

### DIFF
--- a/magda-esri-portal-connector/aspect-templates/group-esri-access-control.js
+++ b/magda-esri-portal-connector/aspect-templates/group-esri-access-control.js
@@ -1,4 +1,4 @@
 return {
     groups: [group.id],
-    access: group.access === "any authenticated users" ? "org" : "shared"
+    access: group.access === "any authenticated users" ? "org" : group.access
 };

--- a/magda-esri-portal-connector/src/EsriPortalTransformer.ts
+++ b/magda-esri-portal-connector/src/EsriPortalTransformer.ts
@@ -18,7 +18,6 @@ type EsriJsonTransformerOptions = JsonTransformerOptions & {
 };
 
 export default class EsriPortalTransformer extends JsonTransformer {
-    public expiration: number | undefined;
     private groupAspectBuilders: AspectBuilder[];
     private groupAspects: CompiledAspects;
 


### PR DESCRIPTION
### What this PR does

Fixes https://github.com/TerriaJS/nsw-digital-twin/issues/273

Add `access` property in the `esri-access-control` aspect for a group record. So if a portal group has `public` access attribute, unauthenticated users will have access to that group record.

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [ ] I've updated CHANGES.md with what I changed.
-   [x] I've linked this PR to an issue in ZenHub (core dev team only)
