### PR TITLE
Revise esri OPA policy.

### DIFF
--- a/deploy/helm/magda/charts/opa/policies/object/registry/record/esri_groups.rego
+++ b/deploy/helm/magda/charts/opa/policies/object/registry/record/esri_groups.rego
@@ -2,5 +2,6 @@ package object.registry.record
 
 # "esri-access-control" is the aspect id defined in the registry database.
 esri_groups {
+    input.object.registry.record["esri-access-control"].access != "private"
     input.object.registry.record["esri-access-control"].groups[_] == input.user.session["esriGroups"][_]
 }

--- a/deploy/helm/magda/charts/opa/policies/object/registry/record/esri_groups_test.rego
+++ b/deploy/helm/magda/charts/opa/policies/object/registry/record/esri_groups_test.rego
@@ -11,7 +11,86 @@ test_allow_all_matched_groups {
             "registry": {
                 "record": {
                     "esri-access-control": {
+                        "groups": ["G1", "G2"],
+                        "access": "shared"
+                    }
+                }
+            }
+        }
+    }
+}
+
+test_allow_org_group {
+    esri_groups with input as {
+        "user": {
+            "session" : {
+            "esriGroups": ["authenticated user group"]
+            }
+        },
+        "object": {
+            "registry": {
+                "record": {
+                    "esri-access-control": {
+                        "groups": ["authenticated user group"],
+                        "access": "org"
+                    }
+                }
+            }
+        }
+    }
+}
+
+test_deny_private_even_if_matched_groups {
+    not esri_groups with input as {
+        "user": {
+            "session" : {
+            "esriGroups": ["G1", "G2"]
+            }
+        },
+        "object": {
+            "registry": {
+                "record": {
+                    "esri-access-control": {
+                        "groups": ["G1", "G2"],
+                        "access": "private"
+                    }
+                }
+            }
+        }
+    }
+}
+
+test_deny_if_missing_access_property {
+    not esri_groups with input as {
+        "user": {
+            "session" : {
+            "esriGroups": ["G1", "G2"]
+            }
+        },
+        "object": {
+            "registry": {
+                "record": {
+                    "esri-access-control": {
                         "groups": ["G1", "G2"]
+                    }
+                }
+            }
+        }
+    }
+}
+
+test_deny_if_missing_group_property {
+    not esri_groups with input as {
+        "user": {
+            "session" : {
+            "esriGroups": ["G1", "G2"]
+            }
+        },
+        "object": {
+            "registry": {
+                "record": {
+                    "esri-access-control": {
+                        "access": "shared"
                     }
                 }
             }
@@ -30,7 +109,8 @@ test_allow_any_matched_groups {
             "registry": {
                 "record": {
                     "esri-access-control": {
-                        "groups": ["G2", "G3"]
+                        "groups": ["G2", "G3"],
+                        "access": "shared"
                     }
                 }
             }

--- a/deploy/helm/magda/charts/opa/policies/object/registry/record/esri_owner_groups_test.rego
+++ b/deploy/helm/magda/charts/opa/policies/object/registry/record/esri_owner_groups_test.rego
@@ -37,7 +37,8 @@ test_allow_read_if_groups_and_permission_are_correct {
             "registry": {
                 "record": {
                     "esri-access-control": {
-                        "groups": ["G2", "G3"]
+                        "groups": ["G2", "G3"],
+                        "access": "shared"
                     }
                 }
             }
@@ -157,7 +158,8 @@ test_allow_read_if_not_owner_but_groups_and_permission_are_correct {
                 "record": {
                     "esri-access-control": {
                         "groups": ["G2", "G3"],
-                        "owner": "Person.B"
+                        "owner": "Person.B",
+                        "access": "shared"
                     }
                 }
             }

--- a/deploy/helm/magda/charts/opa/policies/object/registry/record/esri_owner_test.rego
+++ b/deploy/helm/magda/charts/opa/policies/object/registry/record/esri_owner_test.rego
@@ -27,16 +27,19 @@ test_deny_non_owner {
             }
         },
         "object": {
-            "record": {
-                "esri-access-control": {
-                    "owner": "personB"
+            "registry": {
+                "record": {
+                    "esri-access-control": {
+                        "owner": "personB",
+                        "access": "private"
+                    }
                 }
             }
         }
     }
 }
 
-test_deny_no_access_control_info {
+test_deny_if_missing_owner_property_when_access_is_private {
     not esri_owner with input as {
         "user": {
             "session": {
@@ -44,9 +47,12 @@ test_deny_no_access_control_info {
             }
         },
         "object": {
-            "record": {
-                "esri-access-control": {
-                    "someOtherKey": "personA"
+            "registry": {
+                "record": {
+                    "esri-access-control": {
+                        "someOtherKey": "personA",
+                        "access": "private"
+                    }
                 }
             }
         }

--- a/magda-esri-portal-connector/src/EsriPortal.ts
+++ b/magda-esri-portal-connector/src/EsriPortal.ts
@@ -268,8 +268,8 @@ export default class EsriPortal implements ConnectorSource {
                         // where "any authenticated users" is the value to be checked by
                         // aspect-templates/group-esri-access-control.js.
                         //
-                        // Currently the esri-access-control aspect data property "access" is
-                        // compulsory only if its value is "public".  Otherwise it is optional.
+                        // The esri-access-control aspect data property "access" is
+                        // compulsory -- its value is "public", "private", "shared" or "org".
                         const groupInfo =
                             item.access === "org"
                                 ? {

--- a/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/SqlHelper.scala
+++ b/magda-registry-api/src/main/scala/au/csiro/data61/magda/registry/SqlHelper.scala
@@ -129,6 +129,7 @@ object SqlHelper {
     else if (operation == Lt) SQLSyntax.createUnsafely("<")
     else if (operation == Gte) SQLSyntax.createUnsafely(">=")
     else if (operation == Lte) SQLSyntax.createUnsafely("<=")
+    else if (operation == Neq) SQLSyntax.createUnsafely("!=")
     else
       throw new Exception("Could not understand " + operation)
   }

--- a/magda-registry-api/src/test/resources/data/add-esri-access-control-aspect-groups-and-owner-private-access-only.json
+++ b/magda-registry-api/src/test/resources/data/add-esri-access-control-aspect-groups-and-owner-private-access-only.json
@@ -5,7 +5,7 @@
             "esri-access-control": {
                 "groups": ["Dep. A"],
                 "owner": "user0",
-                "access": "shared"
+                "access": "private"
             }
         }
     },
@@ -15,7 +15,7 @@
             "esri-access-control": {
                 "groups": ["Dep. A", "Branch A, Dep. A"],
                 "owner": "user1",
-                "access": "shared"
+                "access": "private"
             }
         }
     },
@@ -26,7 +26,7 @@
             "esri-access-control": {
                 "groups": ["Dep. A", "Branch B, Dep. A"],
                 "owner": "user2",
-                "access": "shared"
+                "access": "private"
             }
         }
     },
@@ -41,7 +41,7 @@
                     "Section C, Branch B, Dep. A"
                 ],
                 "owner": "user3",
-                "access": "shared"
+                "access": "private"
             }
         }
     },
@@ -50,9 +50,8 @@
         "id": "record-4",
         "aspects": {
             "esri-access-control": {
-                "access": "public",
-                "owner": "user3",
-                "access": "shared"
+                "access": "private",
+                "owner": "user3"
             }
         }
     },
@@ -63,7 +62,7 @@
             "esri-access-control": {
                 "groups": ["Dep. A", "Branch B, Dep. A"],
                 "owner": "user2",
-                "access": "shared"
+                "access": "private"
             }
         }
     }

--- a/magda-registry-api/src/test/resources/data/add-esri-access-control-aspect-groups-and-owner.json
+++ b/magda-registry-api/src/test/resources/data/add-esri-access-control-aspect-groups-and-owner.json
@@ -4,7 +4,8 @@
         "aspects": {
             "esri-access-control": {
                 "groups": ["Dep. A"],
-                "owner": "user0"
+                "owner": "user0",
+                "access": "shared"
             }
         }
     },
@@ -13,7 +14,8 @@
         "aspects": {
             "esri-access-control": {
                 "groups": ["Dep. A", "Branch A, Dep. A"],
-                "owner": "user1"
+                "owner": "user1",
+                "access": "shared"
             }
         }
     },
@@ -23,7 +25,8 @@
         "aspects": {
             "esri-access-control": {
                 "groups": ["Dep. A", "Branch B, Dep. A"],
-                "owner": "user2"
+                "owner": "user2",
+                "access": "shared"
             }
         }
     },
@@ -37,7 +40,8 @@
                     "Branch B, Dep. A",
                     "Section C, Branch B, Dep. A"
                 ],
-                "owner": "user3"
+                "owner": "user3",
+                "access": "shared"
             }
         }
     },
@@ -57,7 +61,8 @@
         "aspects": {
             "esri-access-control": {
                 "groups": ["Dep. A", "Branch B, Dep. A"],
-                "owner": "user2"
+                "owner": "user2",
+                "access": "shared"
             }
         }
     }

--- a/magda-registry-api/src/test/resources/data/add-esri-access-control-aspect-groups-expired.json
+++ b/magda-registry-api/src/test/resources/data/add-esri-access-control-aspect-groups-expired.json
@@ -3,7 +3,8 @@
         "id": "record-0",
         "aspects": {
             "esri-access-control": {
-                "groups": ["Dep. A"]
+                "groups": ["Dep. A"],
+                "access": "shared"
             }
         }
     },
@@ -11,7 +12,8 @@
         "id": "record-1",
         "aspects": {
             "esri-access-control": {
-                "groups": ["Dep. A", "Branch A, Dep. A"]
+                "groups": ["Dep. A", "Branch A, Dep. A"],
+                "access": "shared"
             }
         }
     },
@@ -20,7 +22,8 @@
         "id": "record-2",
         "aspects": {
             "esri-access-control": {
-                "groups": ["Dep. A", "Branch B, Dep. A"]
+                "groups": ["Dep. A", "Branch B, Dep. A"],
+                "access": "shared"
             }
         }
     },
@@ -33,7 +36,8 @@
                     "Dep. A",
                     "Branch B, Dep. A",
                     "Section C, Branch B, Dep. A"
-                ]
+                ],
+                "access": "shared"
             }
         }
     },
@@ -51,7 +55,8 @@
         "id": "record-5",
         "aspects": {
             "esri-access-control": {
-                "groups": ["Dep. A", "Branch B, Dep. A"]
+                "groups": ["Dep. A", "Branch B, Dep. A"],
+                "access": "shared"
             }
         }
     }

--- a/magda-registry-api/src/test/resources/data/add-esri-access-control-aspect-groups-only.json
+++ b/magda-registry-api/src/test/resources/data/add-esri-access-control-aspect-groups-only.json
@@ -3,7 +3,8 @@
         "id": "record-0",
         "aspects": {
             "esri-access-control": {
-                "groups": ["Dep. A"]
+                "groups": ["Dep. A"],
+                "access": "shared"
             }
         }
     },
@@ -11,7 +12,8 @@
         "id": "record-1",
         "aspects": {
             "esri-access-control": {
-                "groups": ["Dep. A", "Branch A, Dep. A"]
+                "groups": ["Dep. A", "Branch A, Dep. A"],
+                "access": "shared"
             }
         }
     },
@@ -20,7 +22,8 @@
         "id": "record-2",
         "aspects": {
             "esri-access-control": {
-                "groups": ["Dep. A", "Branch B, Dep. A"]
+                "groups": ["Dep. A", "Branch B, Dep. A"],
+                "access": "shared"
             }
         }
     },
@@ -33,7 +36,8 @@
                     "Dep. A",
                     "Branch B, Dep. A",
                     "Section C, Branch B, Dep. A"
-                ]
+                ],
+                "access": "shared"
             }
         }
     },
@@ -51,7 +55,8 @@
         "id": "record-5",
         "aspects": {
             "esri-access-control": {
-                "groups": ["Dep. A", "Branch B, Dep. A"]
+                "groups": ["Dep. A", "Branch B, Dep. A"],
+                "access": "shared"
             }
         }
     }

--- a/magda-registry-api/src/test/scala/au/csiro/data61/magda/opa/RecordOpaPolicyWithEsirGroupsAndOwnerPrivateAccessOnlySpec.scala
+++ b/magda-registry-api/src/test/scala/au/csiro/data61/magda/opa/RecordOpaPolicyWithEsirGroupsAndOwnerPrivateAccessOnlySpec.scala
@@ -1,0 +1,851 @@
+package au.csiro.data61.magda.opa
+
+import akka.http.scaladsl.model.StatusCodes
+import au.csiro.data61.magda.model.Registry._
+import au.csiro.data61.magda.registry._
+import spray.json._
+
+abstract class RecordOpaPolicyWithEsirGroupsAndOwnerPrivateAccessOnlySpec
+    extends ApiWithOpa {
+
+  def prepareData(param: FixtureParam): Unit ={
+    createAspectDefinitions(param)
+    createRecords(param)
+    import spray.json._
+    val notExpired = JsObject("id"-> JsString("nsw-portal"), "data" -> JsObject("last crawl expiration" -> JsString("not expired")))
+    updateExtraInput(notExpired)
+  }
+
+  describe("should authorize non-link aspect query") {
+    it(
+      "on specified record (as path param)"
+    ) { param =>
+      prepareData(param)
+
+      userIdsAndExpectedRecordIdIndexesWithoutLink.map(
+        userIdAndExpectedRecordIndexes => {
+          val userId = userIdAndExpectedRecordIndexes._1
+          val expectedRecordIndexes = userIdAndExpectedRecordIndexes._2
+          var foundRecordsCounter = 0
+
+          testRecords.zipWithIndex.map {
+            case (record, recordIndex) =>
+              val recordId = record.id
+
+              Get(s"/v0/records/$recordId/aspects/$organizationId") ~> addTenantIdHeader(
+                TENANT_0
+              ) ~> addJwtToken(userId) ~> param
+                .api(Full)
+                .routes ~> check {
+                val theResponse = responseAs[Option[JsObject]]
+                if (expectedRecordIndexes.contains(recordIndex)) {
+                  status shouldBe StatusCodes.OK
+                  foundRecordsCounter = foundRecordsCounter + 1
+                  theResponse.get.fields("name") shouldBe JsString(
+                    recordOrgNames(recordIndex)
+                  )
+                } else {
+                  status shouldBe StatusCodes.NotFound
+                  theResponse.get.fields("message") shouldBe JsString(
+                    "No record or aspect exists with the given IDs."
+                  )
+                }
+              }
+          }
+
+          foundRecordsCounter shouldBe expectedRecordIndexes.length
+        }
+      )
+    }
+
+    it(
+      "on specified record (as query param)"
+    ) { param =>
+      prepareData(param)
+
+      userIdsAndExpectedRecordIdIndexesWithoutLink.map(
+        userIdAndExpectedRecordIndexes => {
+          val userId = userIdAndExpectedRecordIndexes._1
+          val expectedRecordIndexes = userIdAndExpectedRecordIndexes._2
+          var foundRecordsCounter = 0
+
+          testRecords.zipWithIndex.map {
+            case (record, index) =>
+              val recordId = record.id
+
+              Get(s"/v0/records/$recordId?aspect=$organizationId") ~> addTenantIdHeader(
+                TENANT_0
+              ) ~> addJwtToken(userId) ~> param
+                .api(Full)
+                .routes ~> check {
+                if (expectedRecordIndexes.contains(index)) {
+                  foundRecordsCounter = foundRecordsCounter + 1
+                  val record = responseAs[Option[Record]]
+                  status shouldBe StatusCodes.OK
+                  record.get.id shouldBe "record-" + index
+                  record.get
+                    .aspects(organizationId)
+                    .fields("name") shouldBe JsString(
+                    recordOrgNames(index)
+                  )
+                } else {
+                  status shouldBe StatusCodes.NotFound
+                }
+              }
+          }
+
+          foundRecordsCounter shouldBe expectedRecordIndexes.length
+        }
+      )
+    }
+
+    it(
+      "on all records"
+    ) { param =>
+      prepareData(param)
+
+      userIdsAndExpectedRecordIdIndexesWithoutLink.map(
+        userIdAndExpectedRecordIndexes => {
+          val userId = userIdAndExpectedRecordIndexes._1
+          val expectedRecordIndexes = userIdAndExpectedRecordIndexes._2
+
+          Get(s"/v0/records?aspect=$organizationId") ~> addTenantIdHeader(
+            TENANT_0
+          ) ~> addJwtToken(
+            userId
+          ) ~> param.api(Full).routes ~> check {
+            status shouldBe StatusCodes.OK
+            val records = responseAs[RecordsPage[Record]].records
+            records.length shouldBe expectedRecordIndexes.length
+            val results: List[(Record, Int)] =
+              records.zip(expectedRecordIndexes)
+            results.map(res => {
+              val record = res._1
+              val index = res._2
+              record.id shouldBe "record-" + index
+              record
+                .aspects(organizationId)
+                .fields("name") shouldEqual JsString(
+                recordOrgNames(index)
+              )
+            })
+          }
+        }
+      )
+    }
+
+    it(
+      "on all records without specifying any aspects"
+    ) { param =>
+      prepareData(param)
+
+      userIdsAndExpectedRecordIdIndexesWithoutLink.map(
+        userIdAndExpectedRecordIndexes => {
+          val userId = userIdAndExpectedRecordIndexes._1
+          val expectedRecordIndexes = userIdAndExpectedRecordIndexes._2
+
+          Get(s"/v0/records") ~> addTenantIdHeader(TENANT_0) ~> addJwtToken(
+            userId
+          ) ~> param.api(Full).routes ~> check {
+            status shouldBe StatusCodes.OK
+            val records = responseAs[RecordsPage[Record]].records
+            records.length shouldBe expectedRecordIndexes.length
+            val results: List[(Record, Int)] =
+              records.zip(expectedRecordIndexes)
+            results.map(res => {
+              val record = res._1
+              val index = res._2
+              record.id shouldBe "record-" + index
+              record.aspects shouldBe Map()
+            })
+          }
+        }
+      )
+    }
+
+    it(
+      "on all records with limit"
+    ) { param =>
+      prepareData(param)
+
+      val limit = 3
+      val userIdAndExpectedRecordIndexes = (userId0, List(0))
+
+      val userId = userIdAndExpectedRecordIndexes._1
+      val expectedRecordIndexes = userIdAndExpectedRecordIndexes._2
+
+      Get(s"/v0/records?aspect=$organizationId&limit=$limit") ~> addTenantIdHeader(
+        TENANT_0
+      ) ~> addJwtToken(
+        userId
+      ) ~> param.api(Full).routes ~> check {
+        status shouldBe StatusCodes.OK
+        val records = responseAs[RecordsPage[Record]].records
+        records.length shouldBe expectedRecordIndexes.length
+        val results: List[(Record, Int)] = records.zip(expectedRecordIndexes)
+        results.map(res => {
+          val record = res._1
+          val index = res._2
+          record.id shouldBe "record-" + index
+          record.aspects(organizationId).fields("name") shouldEqual JsString(
+            recordOrgNames(index)
+          )
+        })
+      }
+
+    }
+
+  }
+
+  describe("should authorize page tokens query") {
+    it(
+      "and return different page tokens for different users (with-links aspect)"
+    ) { param =>
+      prepareData(param)
+      val pageSize = 2
+
+      /**
+        *  How the expectedPageTokenOffsetMap is built
+        *
+        *  If the test records are inserted into a clean table (when sequence starts at 0),
+        *  this map represents the expected page token offsets for each users when page size
+        *  is set to 2.
+        *
+        *  The formula for token offset calculation is
+        *
+        *            token offset = record sequence - first token = s - f
+        *
+        *  During test and development, records might be inserted and deleted frequently,
+        *  resulting in non-zero-sequence-based page tokens. The expected page tokens can be
+        *  calculated by the following formula
+        *
+        *             page tokens = first token + token offset = f + offset
+        *
+        *
+        *
+        *   sequence (s)        |  0          1         2         3          4         5
+        *   --------------------+---------------------------------------------------------------
+        *   userId0             |                                [record-3  record-4] [record-5]
+        *   first token (f = 3) |
+        *   token offset(s - f) |                                0          1
+        *   tokens (f + offset) |                                0          4
+        *   --------------------+---------------------------------------------------------------
+        *   userId1             |
+        *   first token (f = 4) |
+        *   token offset (s - f)|
+        *   tokens (f + offset) |
+        *   --------------------+---------------------------------------------------------------
+        *   userId2             |
+        *   first token (f = 3) |
+        *   token offset (s - f)|
+        *   tokens (f + offset) |
+        *   --------------------+---------------------------------------------------------------
+        *   userId3             |                                [record-3  record-4]
+        *   first token (f = 3) |
+        *   token offset (s - f)|                                0          1
+        *   tokens (f + offset) |                                0          4
+        *   --------------------+---------------------------------------------------------------
+        *   anonymous           |
+        *   first token (f = 4) |
+        *   token offset (s - f)|
+        *   tokens (f + offset) |
+        */
+      val expectedPageTokenOffsetMap = Map(
+        adminUser -> List(0, 1), // authorized to record-3, record-4, record-5
+        userId0 -> List(0),
+        userId1 -> List(0),
+        userId2 -> List(0),
+        userId3 -> List(0, 1), // authorized to record-3, record-4
+        anonymous -> List(0)
+      )
+
+      userIdsAndExpectedRecordIdIndexesWithoutLink.map(
+        userIdAndExpectedRecordIndexes => {
+          val userId = userIdAndExpectedRecordIndexes._1
+
+          var firstRecordToken = 0
+          Get(s"/v0/records?aspect=$withLinksId&limit=1") ~> addTenantIdHeader(
+            TENANT_0
+          ) ~> addJwtToken(
+            userId
+          ) ~> param.api(Full).routes ~> check {
+            val page = responseAs[RecordsPage[Record]]
+            if (page.hasMore)
+              firstRecordToken = page.nextPageToken.map(Integer.parseInt).get
+          }
+
+          Get(s"/v0/records/pagetokens?aspect=$withLinksId&limit=$pageSize") ~> addTenantIdHeader(
+            TENANT_0
+          ) ~> addJwtToken(
+            userId
+          ) ~> param.api(Full).routes ~> check {
+            status shouldBe StatusCodes.OK
+            val actualPageTokens = responseAs[List[String]]
+
+            val expectedPageTokens = expectedPageTokenOffsetMap(userId).map(
+              offset => if (offset == 0) 0 else firstRecordToken + offset
+            )
+
+//            println(s"----- $userId, $firstRecordToken, $actualPageTokens")
+            actualPageTokens
+              .map(Integer.parseInt) shouldEqual expectedPageTokens
+          }
+
+        }
+      )
+    }
+
+    it(
+      "and return different page tokens for different users (non-link aspect)"
+    ) { param =>
+      prepareData(param)
+      val pageSize = 3
+
+      /**
+        *  How the expectedPageTokenOffsetMap is built
+        *
+        *  If the test records are inserted into a clean table (when sequence starts at 0),
+        *  this map represents the expected page token offsets for each users when page size
+        *  is set to 3.
+        *
+        *  The formula for token offset calculation is
+        *
+        *            token offset = record sequence - first token = s - f
+        *
+        *  During test and development, records might be inserted and deleted frequently,
+        *  resulting in non-zero-sequence-based page tokens. The expected page tokens can be
+        *  calculated by the following formula (always starts with token 0)
+        *
+        *             page tokens = first token + token offset = f + offset
+        *
+        *
+        *   sequence (s)        | 0          1         2          3          4         5
+        *   --------------------+---------------------------------------------------------------
+        *   userId0             | [record-0  record-1  record-2]  [record-3  record-4  record-5]
+        *   first token (f = 0) |
+        *   token offset        |  0                   2                               5
+        *   tokens (f + offset) |  0                   2                               5
+        *   --------------------+---------------------------------------------------------------
+        *   userId1             |           [record-1]
+        *   first token (f = 1) |
+        *   token offset (s - f)|            0
+        *   tokens (f + offset) |            0
+        *   --------------------+----------------------------------------------------------------
+        *   userId2             |                      [record-2]
+        *   first token (f = 2) |
+        *   token offset (s - f)|                       0
+        *   tokens (f + offset) |                       0
+        *   --------------------+----------------------------------------------------------------
+        *   userId3             |                                  [record-3 record-4]
+        *   first token (f = 3) |
+        *   token offset (s - f)|                                   0
+        *   tokens (f + offset) |                                   0
+        *   --------------------+----------------------------------------------------------------
+        *   anonymous           |
+        *   first token (f = 3) |
+        *   token offset (s - f)|                                             0
+        *   tokens (f + offset) |                                             0
+        */
+      val expectedPageTokenOffsetMap = Map(
+        adminUser -> List(0, 2, 5), // authorized to all 6 records
+        userId0 -> List(0), // authorized to record-0
+        userId1 -> List(0), // authorized to record-1
+        userId2 -> List(0), // authorized to record-2
+        userId3 -> List(0), // authorized to record-3, record-4
+        anonymous -> List(0)
+      )
+
+      userIdsAndExpectedRecordIdIndexesWithoutLink.map(
+        userIdAndExpectedRecordIndexes => {
+          val userId = userIdAndExpectedRecordIndexes._1
+
+          var firstRecordToken = 0
+          Get(s"/v0/records?aspect=$organizationId&limit=1") ~> addTenantIdHeader(
+            TENANT_0
+          ) ~> addJwtToken(
+            userId
+          ) ~> param.api(Full).routes ~> check {
+            val page = responseAs[RecordsPage[Record]]
+            if (page.hasMore)
+              firstRecordToken = page.nextPageToken.map(Integer.parseInt).get
+          }
+
+          Get(s"/v0/records/pagetokens?aspect=$organizationId&limit=$pageSize") ~> addTenantIdHeader(
+            TENANT_0
+          ) ~> addJwtToken(
+            userId
+          ) ~> param.api(Full).routes ~> check {
+            status shouldBe StatusCodes.OK
+            val actualPageTokens = responseAs[List[String]]
+
+            val expectedPageTokens = expectedPageTokenOffsetMap(userId).map(
+              offset => if (offset == 0) 0 else firstRecordToken + offset
+            )
+
+//            println(s"----- $userId, $firstRecordToken, $actualPageTokens")
+            actualPageTokens
+              .map(Integer.parseInt) shouldEqual expectedPageTokens
+          }
+
+        }
+      )
+    }
+
+  }
+
+  describe("should authorize query by aspect value") {
+    def encode(rawQueriedValue: String) = {
+      java.net.URLEncoder.encode(rawQueriedValue, "UTF-8")
+    }
+
+    val valueKey = "name"
+    val queriedValue = encode(recordOrgNames(3)) // org names of record-3 and record-4
+
+    it("and return record-3 and record-4 to userId3") { param =>
+      Get(
+        s"/v0/records?aspectQuery=$organizationId.$valueKey:$queriedValue&aspect=$organizationId"
+      ) ~>
+        addTenantIdHeader(TENANT_0) ~> addJwtToken(userId3) ~> param
+        .api(Full)
+        .routes ~> check {
+        status shouldEqual StatusCodes.OK
+        val page = responseAs[RecordsPage[Record]]
+        page.records.length shouldBe 2
+        val actual1 = page.records.head
+        val expected1 = testRecords(3)
+        actual1.id shouldBe expected1.id
+        actual1.aspects(organizationId).fields(valueKey) shouldBe expected1
+          .aspects(organizationId)
+          .fields(valueKey)
+
+        val actual2 = page.records(1)
+        val expected2 = testRecords(4)
+        actual2.id shouldBe expected2.id
+        actual2.aspects(organizationId).fields(valueKey) shouldBe expected2
+          .aspects(organizationId)
+          .fields(valueKey)
+      }
+    }
+
+    it("and not return any records to anonymous user") { param =>
+      Get(
+        s"/v0/records?aspectQuery=$organizationId.$valueKey:$queriedValue&aspect=$organizationId"
+      ) ~>
+        addTenantIdHeader(TENANT_0) ~> addJwtToken(anonymous) ~> param
+        .api(Full)
+        .routes ~> check {
+        status shouldEqual StatusCodes.OK
+        val page = responseAs[RecordsPage[Record]]
+        page.records.length shouldBe 0
+      }
+    }
+
+  }
+
+  describe("should authorize meta query") {
+    it(
+      "of summary on all records"
+    ) { param =>
+      prepareData(param)
+
+      userIdsAndExpectedRecordIdIndexesWithoutLink.map(
+        userIdAndExpectedRecordIndexes => {
+          val userId = userIdAndExpectedRecordIndexes._1
+          val expectedRecordIndexes = userIdAndExpectedRecordIndexes._2
+
+          Get(s"/v0/records/summary") ~> addTenantIdHeader(TENANT_0) ~> addJwtToken(
+            userId
+          ) ~> param.api(Full).routes ~> check {
+            status shouldBe StatusCodes.OK
+            val records = responseAs[RecordsPage[RecordSummary]].records
+            records.length shouldBe expectedRecordIndexes.length
+            val results: List[(RecordSummary, Int)] =
+              records.zip(expectedRecordIndexes)
+            results.map(res => {
+              val record = res._1
+              val index = res._2
+              record.id shouldBe "record-" + index
+              record.aspects.toSet shouldBe testRecords(index).aspects.keys.toSet
+            })
+          }
+        }
+      )
+    }
+
+    it(
+      "of summary on specified record"
+    ) { param =>
+      prepareData(param)
+
+      userIdsAndExpectedRecordIdIndexesWithoutLink.map(
+        userIdAndExpectedRecordIndexes => {
+          val userId = userIdAndExpectedRecordIndexes._1
+          val expectedRecordIndexes = userIdAndExpectedRecordIndexes._2
+          var foundRecordsCounter = 0
+
+          testRecords.zipWithIndex.map {
+            case (record, recordIndex) =>
+              val recordId = record.id
+
+              Get(s"/v0/records/summary/$recordId") ~> addTenantIdHeader(
+                TENANT_0
+              ) ~> addJwtToken(userId) ~> param
+                .api(Full)
+                .routes ~> check {
+                if (expectedRecordIndexes.contains(recordIndex)) {
+                  status shouldBe StatusCodes.OK
+                  foundRecordsCounter = foundRecordsCounter + 1
+                  val recordSummary = responseAs[RecordSummary]
+                  recordSummary.id shouldBe recordId
+                  recordSummary.aspects.toSet shouldBe testRecords(recordIndex).aspects.keys.toSet
+                } else {
+                  status shouldBe StatusCodes.NotFound
+                }
+              }
+          }
+
+          foundRecordsCounter shouldBe expectedRecordIndexes.length
+        }
+      )
+    }
+
+    it(
+      "of count on all records"
+    ) { param =>
+      prepareData(param)
+
+      userIdsAndExpectedRecordIdIndexesWithoutLink.map(
+        userIdAndExpectedRecordIndexes => {
+          val userId = userIdAndExpectedRecordIndexes._1
+          val expectedRecordIndexes = userIdAndExpectedRecordIndexes._2
+
+          Get(s"/v0/records/count") ~> addTenantIdHeader(TENANT_0) ~> addJwtToken(
+            userId
+          ) ~> param.api(Full).routes ~> check {
+            status shouldBe StatusCodes.OK
+            val countResponse = responseAs[CountResponse]
+            countResponse.count shouldBe expectedRecordIndexes.length
+          }
+        }
+      )
+
+    }
+
+  }
+
+  describe("should authorize single link aspect query") {
+    it(
+      "and not return link to unauthorized user due to private property (dereference=false)"
+    ) { param =>
+      prepareData(param)
+
+      val referencingRecordId = "record-2"
+//      val referencedRecordId = "record-1"
+
+      Get(
+        s"/v0/records/$referencingRecordId?aspect=$withLinkId&dereference=false"
+      ) ~> addTenantIdHeader(TENANT_0) ~> addJwtToken(
+        userId0
+      ) ~> param.api(Full).routes ~> check {
+        status shouldBe StatusCodes.NotFound
+      }
+    }
+
+    it(
+      "and not return link to unauthorized user due to private property (dereference=true)"
+    ) { param =>
+      prepareData(param)
+
+      val referencingRecordId = "record-2"
+//      val referencedRecordIndex = 1 // "record-1"
+
+      Get(
+        s"/v0/records/$referencingRecordId?aspect=$withLinkId&dereference=true"
+      ) ~> addTenantIdHeader(TENANT_0) ~> addJwtToken(
+        userId0
+      ) ~> param.api(Full).routes ~> check {
+        status shouldBe StatusCodes.NotFound
+      }
+    }
+
+    it(
+      "and not return link to unauthorized user (dereference=false)"
+    ) { param =>
+      prepareData(param)
+
+      val referencingRecordIndex = 2
+      val referencingRecordId = "record-" + referencingRecordIndex
+
+      Get(
+        s"/v0/records/$referencingRecordId?aspect=$withLinkId&dereference=false"
+      ) ~> addTenantIdHeader(TENANT_0) ~> addJwtToken(
+        userId2
+      ) ~> param.api(Full).routes ~> check {
+        status shouldBe StatusCodes.OK
+        val record = responseAs[Record]
+        record.id shouldBe referencingRecordId
+        record.aspects(withLinkId).fields(linkName) shouldEqual JsString("")
+      }
+
+      Get(
+        s"/v0/records/$referencingRecordId?aspect=$organizationId&aspect=$withLinkId&dereference=false"
+      ) ~> addTenantIdHeader(TENANT_0) ~> addJwtToken(
+        userId2
+      ) ~> param.api(Full).routes ~> check {
+        status shouldBe StatusCodes.OK
+        val record = responseAs[Record]
+        record.id shouldBe referencingRecordId
+        record.aspects(withLinkId).fields(linkName) shouldBe JsString("")
+        record.aspects(organizationId).fields("name") shouldBe JsString(
+          recordOrgNames(referencingRecordIndex)
+        )
+      }
+    }
+
+    it(
+      "and not return link to unauthorized user (dereference=true)"
+    ) { param =>
+      prepareData(param)
+
+      val referencingRecordIndex = 2
+      val referencingRecordId = "record-" + referencingRecordIndex
+
+      Get(
+        s"/v0/records/$referencingRecordId?aspect=$withLinkId&dereference=true"
+      ) ~> addTenantIdHeader(TENANT_0) ~> addJwtToken(
+        userId2
+      ) ~> param.api(Full).routes ~> check {
+        status shouldBe StatusCodes.OK
+        val record = responseAs[Record]
+        record.id shouldBe referencingRecordId
+        record
+          .aspects(withLinkId)
+          .fields(linkName) shouldEqual JsObject.empty
+      }
+
+      Get(
+        s"/v0/records/$referencingRecordId?aspect=$organizationId&aspect=$withLinkId&dereference=true"
+      ) ~> addTenantIdHeader(TENANT_0) ~> addJwtToken(
+        userId2
+      ) ~> param.api(Full).routes ~> check {
+        status shouldBe StatusCodes.OK
+        val record = responseAs[Record]
+        record.id shouldBe referencingRecordId
+        record.aspects(withLinkId).fields(linkName) shouldBe JsObject.empty
+        record.aspects(organizationId).fields("name") shouldBe JsString(
+          recordOrgNames(referencingRecordIndex)
+        )
+      }
+
+    }
+
+    it(
+      "for all users on all records (dereference=false)"
+    ) { param =>
+      prepareData(param)
+
+      userIdsAndExpectedRecordIdIndexesWithSingleLink.map(
+        userIdAndExpectedRecordIndexes => {
+          val userId = userIdAndExpectedRecordIndexes._1
+          val expectedRecordIndexes = userIdAndExpectedRecordIndexes._2
+
+          Get(s"/v0/records?aspect=$withLinkId") ~> addTenantIdHeader(
+            TENANT_0
+          ) ~> addJwtToken(
+            userId
+          ) ~> param.api(Full).routes ~> check {
+            status shouldBe StatusCodes.OK
+            val records = responseAs[RecordsPage[Record]].records
+            records.length shouldBe expectedRecordIndexes.length
+            val results: List[(Record, Int)] =
+              records.zip(expectedRecordIndexes)
+            results.map(res => {
+              val record = res._1
+              val index = res._2
+              record.id shouldBe "record-" + index
+              record.aspects(withLinkId).fields(linkName) shouldEqual JsString(
+                singleLinkRecordIdMapDereferenceIsFalse((userId, record.id))
+              )
+            })
+          }
+        }
+      )
+    }
+
+    it(
+      "for all users on all records (dereference=true)"
+    ) { param =>
+      prepareData(param)
+
+      userIdsAndExpectedRecordIdIndexesWithSingleLink.map(
+        userIdAndExpectedRecordIndexes => {
+          val userId = userIdAndExpectedRecordIndexes._1
+          val expectedRecordIndexes = userIdAndExpectedRecordIndexes._2
+
+          Get(s"/v0/records?aspect=$withLinkId&dereference=true") ~> addTenantIdHeader(
+            TENANT_0
+          ) ~> addJwtToken(
+            userId
+          ) ~> param.api(Full).routes ~> check {
+            status shouldBe StatusCodes.OK
+            val records = responseAs[RecordsPage[Record]].records
+            records.length shouldBe expectedRecordIndexes.length
+            val results: List[(Record, Int)] =
+              records.zip(expectedRecordIndexes)
+            results.map(res => {
+              val record = res._1
+              val index = res._2
+              record.id shouldBe "record-" + index
+              record.aspects(withLinkId).fields(linkName) shouldEqual
+                singleLinkRecordIdMapDereferenceIsTrue((userId, record.id))
+            })
+          }
+        }
+      )
+    }
+  }
+
+  describe("should authorize array links aspect query") {
+    it(
+      "and not return record-5 and its links record-1 and record-3 to userId0 due to private property (dereference=false)"
+    ) { param =>
+      prepareData(param)
+
+      val referencingRecordId = "record-5"
+
+      Get(
+        s"/v0/records/$referencingRecordId?aspect=$withLinksId&dereference=false"
+      ) ~> addTenantIdHeader(TENANT_0) ~> addJwtToken(
+        userId0
+      ) ~> param.api(Full).routes ~> check {
+        status shouldBe StatusCodes.NotFound
+      }
+    }
+
+    it(
+      "and not return record-5 with its links record-1 and record-3 to userId0 due to private property (dereference=true)"
+    ) { param =>
+      prepareData(param)
+
+      val referencingRecordId = "record-5"
+
+      Get(
+        s"/v0/records/$referencingRecordId?aspect=$withLinksId&dereference=true"
+      ) ~> addTenantIdHeader(TENANT_0) ~> addJwtToken(
+        userId0
+      ) ~> param.api(Full).routes ~> check {
+        status shouldBe StatusCodes.NotFound
+      }
+    }
+
+    it(
+      "and return record-5 without links to userId2 due to private property (dereference=false)"
+    ) { param =>
+      prepareData(param)
+
+      val referencingRecordId = "record-5"
+
+      Get(
+        s"/v0/records/$referencingRecordId?aspect=$withLinksId&dereference=false"
+      ) ~> addTenantIdHeader(TENANT_0) ~> addJwtToken(
+        userId2
+      ) ~> param.api(Full).routes ~> check {
+        status shouldBe StatusCodes.OK
+        val record = responseAs[Record]
+        record.id shouldBe referencingRecordId
+        record.aspects(withLinksId).fields(linksName) shouldEqual JsArray.empty
+      }
+    }
+
+    it(
+      "and return record-5 without links to userId2 (dereference=true)"
+    ) { param =>
+      prepareData(param)
+
+      val referencingRecordId = "record-5" // with links to record-1 and record-3
+
+      Get(
+        s"/v0/records/$referencingRecordId?aspect=$withLinksId&dereference=true"
+      ) ~> addTenantIdHeader(TENANT_0) ~> addJwtToken(
+        userId2
+      ) ~> param.api(Full).routes ~> check {
+        status shouldBe StatusCodes.OK
+        val record = responseAs[Record]
+        record.id shouldBe referencingRecordId
+
+        val actual = record
+          .aspects(withLinksId)
+          .fields(linksName)
+
+        actual shouldEqual JsArray.empty
+      }
+    }
+
+    it(
+      "and not return record-4 and its links referenced by record-4 to anonymous user due to private property (dereference=false)"
+    ) { param =>
+      prepareData(param)
+
+      val referencingRecordId = "record-4" // with links to record-1 and record-3
+      val withLinksAspectId = "withLinks"
+
+      Get(
+        s"/v0/records/$referencingRecordId?aspect=$withLinksAspectId&dereference=false"
+      ) ~> addTenantIdHeader(TENANT_0) ~> addJwtToken(
+        anonymous
+      ) ~> param.api(Full).routes ~> check {
+        status shouldBe StatusCodes.NotFound
+      }
+    }
+
+    it(
+      "and not return record-4 and any links referenced by record-4 to anonymous user due to private property (dereference=true)"
+    ) { param =>
+      prepareData(param)
+
+      val referencingRecordId = "record-4" // with links to record-1 and record-3
+      val withLinksAspectId = "withLinks"
+
+      Get(
+        s"/v0/records/$referencingRecordId?aspect=$withLinksAspectId&dereference=true"
+      ) ~> addTenantIdHeader(TENANT_0) ~> addJwtToken(
+        anonymous
+      ) ~> param.api(Full).routes ~> check {
+        status shouldBe StatusCodes.NotFound
+      }
+    }
+
+    it(
+      "and not return record-3 with empty links to userId2 due to private property (dereference=false)"
+    ) { param =>
+      prepareData(param)
+
+      val referencingRecordId = "record-3" // with links to nothing
+
+      Get(
+        s"/v0/records/$referencingRecordId?aspect=$withLinksId&dereference=false"
+      ) ~> addTenantIdHeader(TENANT_0) ~> addJwtToken(
+        userId2
+      ) ~> param.api(Full).routes ~> check {
+        status shouldBe StatusCodes.NotFound
+      }
+    }
+
+    it(
+      "and not return record-3 with empty links to userId2 due to private property (dereference=true)"
+    ) { param =>
+      prepareData(param)
+
+      val referencingRecordId = "record-3" // with links to nothing
+
+      Get(
+        s"/v0/records/$referencingRecordId?aspect=$withLinksId&dereference=true"
+      ) ~> addTenantIdHeader(TENANT_0) ~> addJwtToken(
+        userId2
+      ) ~> param.api(Full).routes ~> check {
+        status shouldBe StatusCodes.NotFound
+      }
+    }
+  }
+
+}

--- a/magda-registry-api/src/test/scala/au/csiro/data61/magda/opa/TestRecordEsriPolicyWithGroupsAndOwnerPrivateAccessOnly.scala
+++ b/magda-registry-api/src/test/scala/au/csiro/data61/magda/opa/TestRecordEsriPolicyWithGroupsAndOwnerPrivateAccessOnly.scala
@@ -1,0 +1,77 @@
+package au.csiro.data61.magda.opa
+
+import akka.http.scaladsl.model.headers.RawHeader
+import au.csiro.data61.magda.Authentication
+import org.scalatest.Ignore
+
+@Ignore
+class TestRecordEsriPolicyWithGroupsAndOwnerPrivateAccessOnly
+    extends RecordOpaPolicyWithEsirGroupsAndOwnerPrivateAccessOnlySpec {
+  override def testConfigSource: String =
+    s"""
+       |opa.recordPolicyId="object.registry.record.esri_owner_groups"
+    """.stripMargin
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    testRecords = getTestRecords(
+      dataPath + "add-esri-access-control-aspect-groups-and-owner-private-access-only.json"
+    )
+  }
+
+  override val userIdsAndExpectedRecordIdIndexesWithoutLink = List(
+    (adminUser, List(0, 1, 2, 3, 4, 5)),
+    (userId0, List(0)),
+    (userId1, List(1)),
+    (userId2, List(2, 5)),
+    (userId3, List(3, 4)),
+    (anonymous, Nil)
+  )
+
+  override val userIdsAndExpectedRecordIdIndexesWithSingleLink = List(
+    (adminUser, List(2)),
+    (userId0, Nil),
+    (userId1, Nil),
+    (userId2, List(2)),
+    (userId3, Nil),
+    (anonymous, Nil)
+  )
+
+  override def addJwtToken(userId: String): RawHeader = {
+    if (userId.equals(adminUser) || userId.equals(anonymous)) {
+      super.addJwtToken(userId)
+
+    } else {
+
+      /**
+        * The current Java JWT library is not capable of creating custom claims that are json objects.
+        * The typescript library comes to help. These jwt tokens are created by magda-typescript-common/src/test/session/buildJwtForRegistryEsriGroupsAndOwnerOpaTest.ts.
+        *
+        * Follow the steps below to create them.
+        *
+        *     cd magda-typescript-common
+        *     yarn build
+        *     yarn create_esri_groups_owner_jwt
+        *
+        * The jwt will claim session.esriGroups and session.esriUser.
+        */
+      val jwtToken =
+        if (userId.equals("00000000-0000-1000-0000-000000000000"))
+          "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiIwMDAwMDAwMC0wMDAwLTEwMDAtMDAwMC0wMDAwMDAwMDAwMDAiLCJzZXNzaW9uIjp7InNlc3Npb24iOnsiZXNyaUdyb3VwcyI6WyJEZXAuIEEiLCJCcmFuY2ggQSwgRGVwLiBBIiwiQnJhbmNoIEIsIERlcC4gQSIsIlNlY3Rpb24gQywgQnJhbmNoIEIsIERlcC4gQSJdLCJlc3JpVXNlciI6InVzZXIwIn19LCJpYXQiOjE1NzA3NTE4MDd9.6OCdIsvochOosNVYVHcTkJo7zHg_JpHHbusVansoatw"
+        else if (userId.equals("00000000-0000-1000-0001-000000000000"))
+          "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiIwMDAwMDAwMC0wMDAwLTEwMDAtMDAwMS0wMDAwMDAwMDAwMDAiLCJzZXNzaW9uIjp7InNlc3Npb24iOnsiZXNyaUdyb3VwcyI6WyJCcmFuY2ggQSwgRGVwLiBBIl0sImVzcmlVc2VyIjoidXNlcjEifX0sImlhdCI6MTU3MDc1MTgwN30.3ElBELW8hCF0tD1fxFX2ecuBNyGNYyatUr7UpEfLJ3k"
+        else if (userId.equals("00000000-0000-1000-0002-000000000000"))
+          "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiIwMDAwMDAwMC0wMDAwLTEwMDAtMDAwMi0wMDAwMDAwMDAwMDAiLCJzZXNzaW9uIjp7InNlc3Npb24iOnsiZXNyaUdyb3VwcyI6WyJCcmFuY2ggQiwgRGVwLiBBIiwiU2VjdGlvbiBDLCBCcmFuY2ggQiwgRGVwLiBBIl0sImVzcmlVc2VyIjoidXNlcjIifX0sImlhdCI6MTU3MDc1MTgwN30.T2Gkc8K5r2qet7z7LOUIot7DTWsFctc0p7AOT3mZrtI"
+        else if (userId.equals("00000000-0000-1000-0003-000000000000"))
+          "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiIwMDAwMDAwMC0wMDAwLTEwMDAtMDAwMy0wMDAwMDAwMDAwMDAiLCJzZXNzaW9uIjp7InNlc3Npb24iOnsiZXNyaUdyb3VwcyI6WyJTZWN0aW9uIEMsIEJyYW5jaCBCLCBEZXAuIEEiXSwiZXNyaVVzZXIiOiJ1c2VyMyJ9fSwiaWF0IjoxNTcwNzUxODA3fQ.PVWtGVy3s6iTQHL9ax1MnHAOU1K4jaiUyOJrigdUqkM"
+        else
+          ""
+      RawHeader(
+        Authentication.headerName,
+        jwtToken
+      )
+    }
+
+  }
+
+}

--- a/magda-registry-aspects/esri-access-control.schema.json
+++ b/magda-registry-aspects/esri-access-control.schema.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/hyper-schema#",
     "title": "Group-based access Control information of an Esri data item",
-    "description": "Group-based access Control information of an Esri data item. Including: group IDs that are allowed to read the data item.",
+    "description": "Attribute-based access Control information of an Esri data item. Including: access, owner and group IDs that are allowed to read the data item.",
     "type": "object",
     "properties": {
         "groups": {
@@ -20,6 +20,10 @@
         },
         "owner": {
             "title": "Record owner id",
+            "type": "string"
+        },
+        "access": {
+            "title": "Esri access attribute: private, shared, org or public",
             "type": "string"
         }
     }


### PR DESCRIPTION
### What this PR does

Fixes https://github.com/TerriaJS/nsw-digital-twin/issues/333

Esri OPA policy is revised to include data access attribute checking. In particular, grant access to group members if the attribute is not `private`.

Note that the OPA integration tests have been done manually according to 
magda-registry-api/src/test/scala/au/csiro/data61/magda/opa/README.md.

Limited number of tests have been done on local cluster deployment.

### Checklist

-   [x] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [ ] I've updated CHANGES.md with what I changed.
-   [ ] I've linked this PR to an issue in ZenHub (core dev team only)
