### PR TITLE
Add private data to groups.

### DIFF
--- a/magda-esri-portal-connector/src/EsriPortal.ts
+++ b/magda-esri-portal-connector/src/EsriPortal.ts
@@ -242,6 +242,7 @@ export default class EsriPortal implements ConnectorSource {
                 if (
                     item.access === "shared" ||
                     item.access === "public" ||
+                    item.access === "private" ||
                     item.access === "org"
                 ) {
                     const groupInfoPromise = this.requestDatasetGroupInformation(


### PR DESCRIPTION
### What this PR does

Fixes https://github.com/TerriaJS/nsw-digital-twin/issues/331

In a catalogue group, if a data item's access attribute is changed to `private`, it will not be visible to all users, including the data owner, which might not be desirable.  This is due to a bug in the portal connector that does not put private data items in any groups.

This PR will fix this problem.

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable
-   [ ] I've updated CHANGES.md with what I changed.
-   [ ] I've linked this PR to an issue in ZenHub (core dev team only)
